### PR TITLE
Spelling fixes, unclosed paren

### DIFF
--- a/content/docs.da.md
+++ b/content/docs.da.md
@@ -22,7 +22,7 @@ Tak for din interesse i at bidrage til Redox!
 Der findes mange måder at hjælpe os og vi sætter pris på dem alle.
 
 Redox er et stort projekt spredt ud over mange repos som kan findes i
-[Redoxorganisationen på Github](https://github.com/redox-os). Dette dokument,
+[Redoxorganisationen på GitHub](https://github.com/redox-os). Dette dokument,
 [CONTRIBUTING.md](https://github.com/redox-os/redox/blob/master/CONTRIBUTING.md)
 er en guide til at hjælpe nybegyndere med at bidrage.
 

--- a/content/docs.de.md
+++ b/content/docs.de.md
@@ -22,7 +22,7 @@ Danke für Ihr Interesse an Redox mitwirken zu wollen!
 Es gibt viele Möglichkeiten uns zu helfen und wir freuen uns über jeden Beitrag.
 
 Redox ist ein großes Projekt das sich über viele Repositories verteilt, welche Sie in der
-[Redox Organisation auf Github](https://github.com/redox-os) finden können.
+[Redox Organisation auf GitHub](https://github.com/redox-os) finden können.
 Das Dokument [CONTRIBUTING.md](https://github.com/redox-os/redox/blob/master/CONTRIBUTING.md)
 ist ein Leitfaden der Neuankömmlingen helfen soll mitzuwiken.
 

--- a/content/docs.en.md
+++ b/content/docs.en.md
@@ -22,7 +22,7 @@ Thank you for your interest in contributing to Redox!
 There are many ways to help us out and we appreciate all of them.
 
 Redox is a large project spread out across many repos which can be found in the
-[Redox organization on Github](https://github.com/redox-os). This document,
+[Redox organization on GitHub](https://github.com/redox-os). This document,
 [CONTRIBUTING.md](https://github.com/redox-os/redox/blob/master/CONTRIBUTING.md)
 is a guide to help newcomers contribute!
 

--- a/content/docs.es.md
+++ b/content/docs.es.md
@@ -22,7 +22,7 @@ Recomendamos encarecidamente empezar con el [Libro](https://doc.redox-os.org/boo
 Hay muchas formas de ayudarnos y apreciamos cada una de ellas.
 
 Redox es un gran proyecto separado en muchos repositorios que se pueden encontrar en la
-[Organización de Redox en Github](https://github.com/redox-os). Este documento,
+[Organización de Redox en GitHub](https://github.com/redox-os). Este documento,
 [CONTRIBUYENDO.md](https://github.com/redox-os/redox/blob/master/CONTRIBUTING.md),
  ¡es una guía para ayudar a los recién llegados a contribuir!
 
@@ -30,7 +30,7 @@ Redox es un gran proyecto separado en muchos repositorios que se pueden encontra
 
 La forma mas rápida y abierta de comunicarse con el equipo de Redox es en 
 nuestro servidor de chat. Actualmente, la única forma de acceder es enviando 
-un correo electrónico a [info@redox-os.org](mailto:info@redox-os.org, 
+un correo electrónico a [info@redox-os.org](mailto:info@redox-os.org), 
 lo cual puede llevar un tiempo, ya que no es automático. Actualmente estamos 
 trabajando en una forma más rápida de hacerlo, pero esta es la más 
 conveniente actualmente.

--- a/content/docs.fr.md
+++ b/content/docs.fr.md
@@ -22,7 +22,7 @@ Merci pour votre intérêt dans Redox!
 Il y a de nombreuses façons de contribuer au projet, nous apprécions votre l'aide.
 
 Le projet Redox est distribué parmi plusieurs répertoires disponibles
-[sur Github dans l'organisation Redox](https://github.com/redox-os). Le document
+[sur GitHub dans l'organisation Redox](https://github.com/redox-os). Le document
 [CONTRIBUTING.md](https://github.com/redox-os/redox/blob/master/CONTRIBUTING.md)
 est un bon départ!
 

--- a/content/docs.no.md
+++ b/content/docs.no.md
@@ -22,7 +22,7 @@ Takk for din interesse i å bidra til Redox!
 Det finnes mange måter å hjelpe oss og vi setter pris på dem alle.
 
 Redox er et stort prosjekt spredt ut over mange repos som kan finnes i
-[Redoxorganisasjon på Github](https://github.com/redox-os). Dette dokumentet,
+[Redoxorganisasjon på GitHub](https://github.com/redox-os). Dette dokumentet,
 [CONTRIBUTING.md](https://github.com/redox-os/redox/blob/master/CONTRIBUTING.md)
 er en guide for å hjelpe nybegynnere til å bidra.
 

--- a/content/docs.sv.md
+++ b/content/docs.sv.md
@@ -22,7 +22,7 @@ Tack för ditt intresse av att bidra till Redox!
 Det finns många sätt att hjälpa oss och vi uppskattar dem
 
 Redox är ett stort projekt utspridda över många repos som kan hittas i
-[Redox organisationan på Github](https://github.com/redox-os). Det här dokumentet,
+[Redox organisationan på GitHub](https://github.com/redox-os). Det här dokumentet,
 [CONTRIBUTING.md](https://github.com/redox-os/redox/blob/master/CONTRIBUTING.md)
 är en guide för att hjälpa nybörjare bidra!
 

--- a/content/docs.zh.md
+++ b/content/docs.zh.md
@@ -21,7 +21,7 @@ date = "2016-03-25T10:42:20-07:00"
 非常感谢您有兴趣为Redox做贡献！
 有很多可以帮助我们的方式，我们喜欢任何形式的帮助。
 
-Redox是一个非常大的工程， 分散在[Github的Redox](https://github.com/redox-os)里的很多代码库里面。
+Redox是一个非常大的工程， 分散在[GitHub的Redox](https://github.com/redox-os)里的很多代码库里面。
 . 这个[文档](https://github.com/redox-os/redox/blob/master/CONTRIBUTING.md)可以帮助新人了解如何为Redox做贡献!
 
 ## 聊天室

--- a/content/screens.da.md
+++ b/content/screens.da.md
@@ -10,5 +10,5 @@ date = "2016-03-25T10:42:20-07:00"
 ## ASUS eeePC 900
 <img class="img-responsive" src="/img/hardware/asus-eepc-900.png"/>
 
-## Thinkpad T-420
+## ThinkPad T420
 <img class="img-responsive" src="/img/hardware/thinkpad-t420.png"/>

--- a/content/screens.de.md
+++ b/content/screens.de.md
@@ -10,5 +10,5 @@ date = "2016-03-25T10:42:20-07:00"
 ## ASUS eeePC 900
 <img class="img-responsive" src="/img/hardware/asus-eepc-900.png"/>
 
-## Thinkpad T-420
+## ThinkPad T420
 <img class="img-responsive" src="/img/hardware/thinkpad-t420.png"/>

--- a/content/screens.en.md
+++ b/content/screens.en.md
@@ -10,5 +10,5 @@ date = "2016-03-25T10:42:20-07:00"
 ## ASUS eeePC 900
 <img class="img-responsive" src="/img/hardware/asus-eepc-900.png"/>
 
-## Thinkpad T-420
+## ThinkPad T420
 <img class="img-responsive" src="/img/hardware/thinkpad-t420.png"/>

--- a/content/screens.eo.md
+++ b/content/screens.eo.md
@@ -10,5 +10,5 @@ date = "2016-03-25T10:42:20-07:00"
 ## ASUS eeePC 900
 <img class="img-responsive" src="/img/hardware/asus-eepc-900.png"/>
 
-## Thinkpad T-420
+## ThinkPad T420
 <img class="img-responsive" src="/img/hardware/thinkpad-t420.png"/>

--- a/content/screens.es.md
+++ b/content/screens.es.md
@@ -10,5 +10,5 @@ date = "2016-03-25T10:42:20-07:00"
 ## ASUS eeePC 900
 <img class="img-responsive" src="/img/hardware/asus-eepc-900.png"/>
 
-## Thinkpad T-420
+## ThinkPad T420
 <img class="img-responsive" src="/img/hardware/thinkpad-t420.png"/>

--- a/content/screens.fr.md
+++ b/content/screens.fr.md
@@ -10,5 +10,5 @@ date = "2016-03-25T10:42:20-07:00"
 ## ASUS eeePC 900
 <img class="img-responsive" src="/img/hardware/asus-eepc-900.png"/>
 
-## Thinkpad T-420
+## ThinkPad T420
 <img class="img-responsive" src="/img/hardware/thinkpad-t420.png"/>

--- a/content/screens.no.md
+++ b/content/screens.no.md
@@ -10,5 +10,5 @@ date = "2016-03-25T10:42:20-07:00"
 ## ASUS eeePC 900
 <img class="img-responsive" src="/img/hardware/asus-eepc-900.png"/>
 
-## Thinkpad T-420
+## ThinkPad T420
 <img class="img-responsive" src="/img/hardware/thinkpad-t420.png"/>

--- a/content/screens.sv.md
+++ b/content/screens.sv.md
@@ -10,5 +10,5 @@ date = "2016-03-25T10:42:20-07:00"
 ## ASUS eeePC 900
 <img class="img-responsive" src="/img/hardware/asus-eepc-900.png"/>
 
-## Thinkpad T-420
+## ThinkPad T420
 <img class="img-responsive" src="/img/hardware/thinkpad-t420.png"/>

--- a/content/screens.zh.md
+++ b/content/screens.zh.md
@@ -10,5 +10,5 @@ date = "2016-03-25T10:42:20-07:00"
 ## 华硕 eeePC 900
 <img class="img-responsive" src="/img/hardware/asus-eepc-900.png"/>
 
-## 联想Thinkpad T-420
+## 联想ThinkPad T420
 <img class="img-responsive" src="/img/hardware/thinkpad-t420.png"/>


### PR DESCRIPTION
**Documentation:**
* Changed the spelling of Git**h**ub to Git**H**ub
* There was an unclosed paren in the Spanish documentation

**Screenshots:**
* According to the [Lenovo Support site](http://support.lenovo.com/hu/en/products/Laptops-and-netbooks/ThinkPad-T-Series-laptops/ThinkPad-T420), the correct name of that laptop is ThinkPad T420.