### PR TITLE
Fix an error in translation of «software driver» to esperanto

### DIFF
--- a/content/home.eo.md
+++ b/content/home.eo.md
@@ -29,7 +29,7 @@ date = "2016-12-07T08:26:00-07:00"
   <div class="col-md-6">
     <ul class="laundry-list">
       <li>MIT licenco</li>
-      <li>Ŝoforoj kuri en Userspace</li>
+      <li>Peliloj kuri en Userspace</li>
       <li>Inkluzivas komunaj Unikso komandojn</li>
       <li>Newlib port por C programs</li>
     </ul>


### PR DESCRIPTION
`Ŝoforo` is a person who can drive a car. 
`Pelilo` is a device driver or software driver.
There was another word `Zorgilo` for device drivers, but it seems less popular or even deprecated now.