### PR TITLE
Omit empty RSS links from <head>

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -7,7 +7,9 @@
 
     <title>{{ .Title }} - {{ .Site.Title }}</title>
     <link rel="canonical" href="{{ .Permalink }}">
+    {{ if .RSSLink }}
     <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}">
+    {{ end }}
 
     <link rel="icon" type="image/png" href="/favicon.png" />
 


### PR DESCRIPTION
Currently the website show an RSS `<link>` tag on every page, even if the template variable `{{ .RSSLink }}` is not set. This results in tags like pointing to `""` (`<link href="" ...>`), which is an HTML document.

This PR changes the websites behaviour such that no `<link>` tags are generated when the `{{ .RSSLink }}` variable is not set.