### PR TITLE
Use HTTPS where possible

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 weight = 1
-baseurl = "http://www.redox-os.org/"
+baseurl = "https://www.redox-os.org/"
 title = "Redox - Your Next(Gen) OS"
 DefaultContentLanguage = "en"
 

--- a/content/docs.cz.md
+++ b/content/docs.cz.md
@@ -37,4 +37,4 @@ Rovněž můžete najít Redox na Redditu:
 
 ## Chování
 
-Držíme se [Rust Code of Conduct](http://www.rust-lang.org/conduct.html)
+Držíme se [Rust Code of Conduct](https://www.rust-lang.org/conduct.html)

--- a/content/docs.da.md
+++ b/content/docs.da.md
@@ -37,4 +37,4 @@ Du kan også finde Redox på Reddit:
 [/r/redox/](https://www.reddit.com/r/redox). Den ugenlige opdatering er lagt ud på det første link.
 
 ## Opførsel
-Vi følger Rusts [regler for god opførsel](http://www.rust-lang.org/conduct.html).
+Vi følger Rusts [regler for god opførsel](https://www.rust-lang.org/conduct.html).

--- a/content/docs.de.md
+++ b/content/docs.de.md
@@ -38,5 +38,5 @@ Sie können Redox auch auf Reddit finden: unter [/r/rust/](https://www.reddit.co
 
 ## Verhaltensweisen
 
-Wir haben für uns beschlossen, dem [Rust Code of Conduct](http://www.rust-lang.org/conduct.html) zu
+Wir haben für uns beschlossen, dem [Rust Code of Conduct](https://www.rust-lang.org/conduct.html) zu
 folgen.

--- a/content/docs.en.md
+++ b/content/docs.en.md
@@ -41,4 +41,4 @@ the former.
 
 ## Conduct
 
-We follow the [Rust Code of Conduct](http://www.rust-lang.org/conduct.html)
+We follow the [Rust Code of Conduct](https://www.rust-lang.org/conduct.html)

--- a/content/docs.eo.md
+++ b/content/docs.eo.md
@@ -37,4 +37,4 @@ Vi povas ankaŭ trovi Redox sur Reddit en
 
 ## Code of Conduct
 
-Ni sekvas la [Rust Code of Conduct](http://www.rust-lang.org/conduct.html).
+Ni sekvas la [Rust Code of Conduct](https://www.rust-lang.org/conduct.html).

--- a/content/docs.es.md
+++ b/content/docs.es.md
@@ -40,4 +40,4 @@ escribe en la primera.
 
 ## Conducta
 
-Seguimos el [Código de Conducta de Rust](http://www.rust-lang.org/conduct.html)
+Seguimos el [Código de Conducta de Rust](https://www.rust-lang.org/conduct.html)

--- a/content/docs.hu.md
+++ b/content/docs.hu.md
@@ -29,4 +29,4 @@ A Redox megtalálható a Redditen is a [/r/rust/](https://www.reddit.com/r/rust)
 
 ## Magatartás
 
-A [Rust magatartási kódexet](http://www.rust-lang.org/conduct.html) követjük.
+A [Rust magatartási kódexet](https://www.rust-lang.org/conduct.html) követjük.

--- a/content/docs.it.md
+++ b/content/docs.it.md
@@ -39,4 +39,4 @@ sulla prima pagina.
 
 ## Condotta
 
-Noi seguiamo il [Codice di Condotta di Rust](http://www.rust-lang.org/conduct.html)
+Noi seguiamo il [Codice di Condotta di Rust](https://www.rust-lang.org/conduct.html)

--- a/content/docs.jp.md
+++ b/content/docs.jp.md
@@ -34,4 +34,4 @@ Reddit上（[/r/rust/](https://www.reddit.com/r/rust)と[/r/redox/](https://www.
 
 ## 規約
 
-[Rustコード規約](http://www.rust-lang.org/conduct.html)に従います。
+[Rustコード規約](https://www.rust-lang.org/conduct.html)に従います。

--- a/content/docs.ko.md
+++ b/content/docs.ko.md
@@ -37,4 +37,4 @@ Redox는 여러 개의 저장소로 이루어진 하나의 거대한 프로젝�
 
 ## 행동규칙
 
-저희는 [Rust Code of Conduct](http://www.rust-lang.org/conduct.html)를 따르고 있습니다.
+저희는 [Rust Code of Conduct](https://www.rust-lang.org/conduct.html)를 따르고 있습니다.

--- a/content/docs.nl.md
+++ b/content/docs.nl.md
@@ -38,4 +38,4 @@ Je kunt Redox ook vinden op reddit onder
 
 ## Gedrag
 
-We volgen de [Rust Code of Conduct](http://www.rust-lang.org/conduct.html)
+We volgen de [Rust Code of Conduct](https://www.rust-lang.org/conduct.html)

--- a/content/docs.no.md
+++ b/content/docs.no.md
@@ -37,4 +37,4 @@ Du kan også finne Redox på Reddit:
 [/r/redox/](https://www.reddit.com/r/redox). Den ukentlige oppdateringen legges ut på den første.
 
 ## Opførsel
-Vi følger Rusts [regler for god oppførsel](http://www.rust-lang.org/conduct.html).
+Vi følger Rusts [regler for god oppførsel](https://www.rust-lang.org/conduct.html).

--- a/content/docs.pl.md
+++ b/content/docs.pl.md
@@ -30,4 +30,4 @@ Możesz nas również znaleźć na Reddicie: [/r/rust/](https://www.reddit.com/r
 
 ## Zasady Postępowania
 
-Przestrzegamy [Zasad Postępowania Rust](http://www.rust-lang.org/conduct.html)
+Przestrzegamy [Zasad Postępowania Rust](https://www.rust-lang.org/conduct.html)

--- a/content/docs.pt.md
+++ b/content/docs.pt.md
@@ -31,4 +31,4 @@ Você também pode encontrar o Redox no Reddit através dos subreddits [/r/rust/
 
 ## Conduta
 
-Nós seguimos o [Código de Conduta do Rust](http://www.rust-lang.org/conduct.html)
+Nós seguimos o [Código de Conduta do Rust](https://www.rust-lang.org/conduct.html)

--- a/content/docs.ru.md
+++ b/content/docs.ru.md
@@ -34,4 +34,4 @@ Redox - огромный проект, разбитый на несколько 
 
 ## Кодекс
 
-Мы используем [Кодекс поведения Rust](http://www.rust-lang.org/conduct.html)
+Мы используем [Кодекс поведения Rust](https://www.rust-lang.org/conduct.html)

--- a/content/docs.sv.md
+++ b/content/docs.sv.md
@@ -37,4 +37,4 @@ Du kan också hitta Redox på Reddit i
 
 ## Uppförande
 
-Vi följer [Rusts uppföranderegler](http://www.rust-lang.org/conduct.html)
+Vi följer [Rusts uppföranderegler](https://www.rust-lang.org/conduct.html)

--- a/content/docs.tr.md
+++ b/content/docs.tr.md
@@ -38,4 +38,4 @@ yayınlanmaktadır.
 
 ## Davranış
 
-Biz [Rust Davranış Kodu](http://www.rust-lang.org/conduct.html)nu takip ediyoruz.
+Biz [Rust Davranış Kodu](https://www.rust-lang.org/conduct.html)nu takip ediyoruz.

--- a/content/docs.zh.md
+++ b/content/docs.zh.md
@@ -34,4 +34,4 @@ Redox是一个非常大的工程， 分散在[GitHub的Redox](https://github.com
 
 ## 行为守则
 
-我们遵守 [Rust代码规范](http://www.rust-lang.org/conduct.html)
+我们遵守 [Rust代码规范](https://www.rust-lang.org/conduct.html)

--- a/content/news/gsoc-self-hosting-3.md
+++ b/content/news/gsoc-self-hosting-3.md
@@ -28,7 +28,7 @@ I added [uname](https://github.com/redox-os/kernel/pull/39) to the sys scheme, a
 
 I've been using expr from uutils (a Rust implementation of coreutils), since Redox's coreutils doesn't provide that currently. Redox should use uutils utilities for that and more; I've [patched chmod](https://github.com/uutils/coreutils/pull/1054) from uutils to run on Redox, and submitted a PR upstream. I intend to look into making Redox use portions of uutils by default where suitable.
 
-I've looked into porting Perl (which would be needed to run autotools itself). Perl is awkward to cross compile though, and there are still some issues, so that isn't available yet. Perl requires ssh access a target machine to cross-compile (yes, really); but luckily a project called [perl-cross](http://arsv.github.io/perl-cross/) provides an alternate build system to address that. That much seems to work, but some other things need to be fixed.
+I've looked into porting Perl (which would be needed to run autotools itself). Perl is awkward to cross compile though, and there are still some issues, so that isn't available yet. Perl requires ssh access a target machine to cross-compile (yes, really); but luckily a project called [perl-cross](https://arsv.github.io/perl-cross/) provides an alternate build system to address that. That much seems to work, but some other things need to be fixed.
 
 # Upstreaming
 

--- a/content/news/the-internet-on-redox.md
+++ b/content/news/the-internet-on-redox.md
@@ -23,11 +23,11 @@ Major changes to the Redox network stack allow for routing to the internet and b
  - This means we can kinda code in rust from redox via #rust's playbot ;-)
 - added basic netcat command, `nc`
 
-#### Images downloaded from [here](http://static.redox-os.org) using `wget`
+#### Images downloaded from [here](https://static.redox-os.org) using `wget`
 <img class="img-responsive" src="https://chat.redox-os.org/api/v3/public/files/get/zoa4meoqjbbcdju9ghd7745phe/aduzjsjphirwtj6togzspotzko/6izutbttt3fhmqxrbihouu6i1c/umrx67rhwifrirabmjznweozaa/works.png?d=%7B%22filename%22%3A%22umrx67rhwifrirabmjznweozaa%2Fworks.png%22%7D&h=%242a%2410%24Qo9E5tp5RaJFUrLdB3jweedFDlroJTjs4KoK16DdkKRL1unXEX0Ke"/>
 
 #### IRC client
-<img class="img-responsive" src="http://i.imgur.com/98vCnlu.png"/>
+<img class="img-responsive" src="https://i.imgur.com/98vCnlu.png"/>
 
 ## 2. Ralloc.
 
@@ -95,7 +95,7 @@ Using [rusttype](https://github.com/dylanede/rusttype), we are able to display T
 - Viewer will show alpha as a grid like the other image viewers
 
 #### Start menu and character map
-<img class="img-responsive" src="http://i.imgur.com/E28ATd4.png"/>
+<img class="img-responsive" src="https://i.imgur.com/E28ATd4.png"/>
 
 ## 4. Games
 - added reblox
@@ -119,7 +119,7 @@ Lots of changes have been happening beneath the hood to ensure feature completen
 - colorized default prompt for ion
 
 #### Terminal with TTF fonts, obligatory `screenfetch`
-<img class="img-responsive" src="http://i.imgur.com/YDCSuiz.png"/>
+<img class="img-responsive" src="https://i.imgur.com/YDCSuiz.png"/>
 
 ## 6. Handbook
 We have started a handbook, which can be viewed [here](https://github.com/redox-os/handbook/blob/master/index.md), and made a terminal viewer for MD files
@@ -128,7 +128,7 @@ We have started a handbook, which can be viewed [here](https://github.com/redox-
 - less and mdless can read from a pipe by reconnecting to the terminal (only works in kernel terminal until PTTY system)
 
 #### `info` displaying the Redox handbook, using `mdless`
-<img class="img-responsive" src="http://i.imgur.com/beTS2Dz.png"/>
+<img class="img-responsive" src="https://i.imgur.com/beTS2Dz.png"/>
 
 ## 7. RedoxFS
 Our filesystem, [RedoxFS](https://github.com/redox-os/redoxfs), can be used on Linux using FUSE and has been tested thoroughly, builds are done by mounting a new filesystem using the FUSE driver.

--- a/content/news/this-summer-in-redox-15.md
+++ b/content/news/this-summer-in-redox-15.md
@@ -6,13 +6,13 @@ title = "This Summer in Redox"
 
 Lately, we've been kind of silent, because we've focused on the coding, and we have a lot of exciting news for everyone.
 
-# A Complete Rewrite of the Kernel ([@jackpot51](http://github.com/jackpot51))
+# A Complete Rewrite of the Kernel ([@jackpot51](https://github.com/jackpot51))
 
 Since August 13, the kernel is going through a complete rewrite, which makes the kernel space ultra-small (about the size of [L4](https://en.wikipedia.org/wiki/L4_microkernel_family)). Everything which can run outside the kernel in practice, will do so.
 
 It is almost complete and will likely be merged in the coming week. [You can find it on GitHub here.](https://github.com/redox-os/redox/)
 
-Thanks to [@jackpot51](http://github.com/jackpot51) for the great [implementation work](https://github.com/redox-os/redox/commits/master).
+Thanks to [@jackpot51](https://github.com/jackpot51) for the great [implementation work](https://github.com/redox-os/redox/commits/master).
 
 ## Reasons for the Rewrite
 
@@ -126,7 +126,7 @@ Instead of being stringly typed, URLs (resource descriptors) are now described b
 
 Overall, the code quality of the new kernel is much better.
 
-### Work-in-progress: Capabilities ([@ticki](http://github.com/ticki))
+### Work-in-progress: Capabilities ([@ticki](https://github.com/ticki))
 
 Capabilities are an interesting way of managing privileges and permissions in many modern kernels. Redox is planning to adopting this. [Scheme-centric capabilities](https://github.com/ticki/kernel) are being designed and implemented.
 
@@ -134,9 +134,9 @@ Capabilities themselves are simply a byte buffer and some restrictions on how th
 
 The scheme can then check if the user of the scheme has the correct capabilities to do a particular action.
 
-# Ralloc is now 2x faster! ([@ticki](http://github.com/ticki))
+# Ralloc is now 2x faster! ([@ticki](https://github.com/ticki))
 
-[Ralloc, the memory allocator of Redox](https://github.com/redox-os/ralloc/tree/skiplist) is going through a major performance pass. I've been working on this for some time now, and the big deal-breaker is really that I switch from a flat array to skiplists. More information can be found [here](http://ticki.github.io/blog/skip-lists-done-right/).
+[Ralloc, the memory allocator of Redox](https://github.com/redox-os/ralloc/tree/skiplist) is going through a major performance pass. I've been working on this for some time now, and the big deal-breaker is really that I switch from a flat array to skiplists. More information can be found [here](https://ticki.github.io/blog/skip-lists-done-right/).
 
 ## Logarithmic allocation tree traversal
 
@@ -172,13 +172,13 @@ The test suite of ralloc has been expanded significantly.
 
 A WIP paper on the design and implementation of ralloc can be found [here](https://github.com/redox-os/ralloc/tree/skiplist/paper). Eventually, ralloc will be formally verified as well.
 
-# Formal verification ([@ticki](http://github.com/ticki))
+# Formal verification ([@ticki](https://github.com/ticki))
 
 A major step towards formalizing and verifying the kernel has been made. In particular, I've constructed a model of the Rust MIR's semantics in terms of Hoare logic and separation logic.
 
-You can read more about this [here](http://ticki.github.io/blog/a-hoare-logic-for-rust/).
+You can read more about this [here](https://ticki.github.io/blog/a-hoare-logic-for-rust/).
 
-# An important update on the ZFS implementation ([@ticki](http://github.com/ticki))
+# An important update on the ZFS implementation ([@ticki](https://github.com/ticki))
 
 The work on the ZFS implementation has been limited in the past few months. This can be attributed to mainly the fact that following the specification word-by-word is a big limitation without significant benefits.
 
@@ -232,11 +232,11 @@ TFS implements a significant part of the stack as disk drivers, transforming the
 
 This is a major improvement over the approach taken by most other file systems, not because of any semantic changes, but simply because it simplifies the implementation a great deal.
 
-# Major refactoring in coreutils ([@stratact](http://github.com/stratact))
+# Major refactoring in coreutils ([@stratact](https://github.com/stratact))
 
-A lot of things in Redox's [coreutils](https://github.com/redox-os/coreutils) has been changed. [@stratact](http://github.com/stratact) has implemented a command-line flag parser and added multiple new features to various utilities, as well as fixing bugs and cleaning up code.
+A lot of things in Redox's [coreutils](https://github.com/redox-os/coreutils) has been changed. [@stratact](https://github.com/stratact) has implemented a command-line flag parser and added multiple new features to various utilities, as well as fixing bugs and cleaning up code.
 
-[@stratact](http://github.com/stratact) also removed a hack in `libextra`'s `GetSlice` implementation since the `std` crate introduce `Option<T>` conversion since Rust 1.12. He improve `Orbtk`'s API to be more user friendly.
+[@stratact](https://github.com/stratact) also removed a hack in `libextra`'s `GetSlice` implementation since the `std` crate introduce `Option<T>` conversion since Rust 1.12. He improve `Orbtk`'s API to be more user friendly.
 
 # Porting stuff
 

--- a/content/news/this-week-in-redox-1.md
+++ b/content/news/this-week-in-redox-1.md
@@ -13,7 +13,7 @@ This is the first post in a blog series tracking the development and progress of
 - The development of Redox's package manager, Oxide (`ox` for short), has started. The source for Oxide can be found [here](https://github.com/redox-os/oxide).
 - [@jackpot51](https://github.com/jackpot51), [@stratact](https://github.com/stratact), and [@tedsta](https://github.com/tedsta) have started implementing support for ZFS, which is planned to be the main file system used in Redox.
 - [@ticki](https://github.com/ticki) made an icon for Redox (see screenshots).
-- [@hauleth](https://github.com/hauleth) set up a cool website, using [Hugo](http://gohugo.io).
+- [@hauleth](https://github.com/hauleth) set up a cool website, using [Hugo](https://gohugo.io).
 - [@ticki](https://github.com/ticki) cleaned up the style in the whole codebase.
 - [@esell](https://github.com/esell) cargoified a lot of crates in the main repository.
 

--- a/content/news/this-week-in-redox-12.md
+++ b/content/news/this-week-in-redox-12.md
@@ -77,12 +77,12 @@ If you have any questions, ideas, or are curious about Redox, we recommend joini
 
 # Handy links
 
-1. [The Glorious Book](http://www.redox-os.org/book/book/)
+1. [The Glorious Book](https://www.redox-os.org/book/book/)
 2. [The Holiest Forum](https://discourse.redox-os.org/)
 3. [The Shiny ISOs](https://static.redox-os.org/)
 4. [Redocs](https://doc.redox-os.org/kernel/)
 5. [Fancy GitHub organization](https://github.com/redox-os)
-6. [Our Holy Grail of a Website](http://www.redox-os.org/)
+6. [Our Holy Grail of a Website](https://www.redox-os.org/)
 
 # What's next?
 

--- a/content/news/this-week-in-redox-13.md
+++ b/content/news/this-week-in-redox-13.md
@@ -13,7 +13,7 @@ If you have any questions, ideas, or are curious about Redox, we recommend joini
 
 # What's new in Redox?
 
-- We've been featured on [InfoWorld](http://www.infoworld.com/article/3046100/open-source-tools/rusts-redox-os-could-show-linux-a-few-new-tricks.html) ("Rust's Redox OS Could Show Linux a Few New Tricks"), [Linux.com](https://www.linux.com/news/software/applications/894311-rusts-redox-os-could-show-linux-a-few-new-tricks), [Phoronix](https://www.phoronix.com/scan.php?page=news_item&px=Redos-OS-Intro), [OSNews](http://www.osnews.com/story/29131/The_Redox_operating_system), and probably more.
+- We've been featured on [InfoWorld](https://www.infoworld.com/article/3046100/open-source-tools/rusts-redox-os-could-show-linux-a-few-new-tricks.html) ("Rust's Redox OS Could Show Linux a Few New Tricks"), [Linux.com](https://www.linux.com/news/software/applications/894311-rusts-redox-os-could-show-linux-a-few-new-tricks), [Phoronix](https://www.phoronix.com/scan.php?page=news_item&px=Redos-OS-Intro), [OSNews](https://www.osnews.com/story/29131/The_Redox_operating_system), and probably more.
 
 - [@ticki](https://github.com/ticki) has has started [libmalloc](https://github.com/redox-os/libmalloc), an efficient userspace memory allocator for Redox.
 
@@ -51,7 +51,7 @@ If you have any questions, ideas, or are curious about Redox, we recommend joini
 
 - We finally reached [3,500 stargazers](https://github.com/redox-os/redox).
 
-- [@ticki](https://github.com/ticki) has added a [Code of Conduct](http://www.redox-os.org/coc/). It is based on Rust's with some slight modifications.
+- [@ticki](https://github.com/ticki) has added a [Code of Conduct](https://www.redox-os.org/coc/). It is based on Rust's with some slight modifications.
 
 - [@jackpot51](https://github.com/jackpot51) has been working on IO from userspace.
 
@@ -97,15 +97,15 @@ Hello world from Java:
 
 Redox running on Thinkpad T-420:
 
-<img class="img-responsive" src="http://www.redox-os.org/img/hardware/thinkpad-t420.png"/>
+<img class="img-responsive" src="https://www.redox-os.org/img/hardware/thinkpad-t420.png"/>
 
 Redox running on ASUS eeePC 900:
 
-<img class="img-responsive" src="http://www.redox-os.org/img/hardware/asus-eepc-900.png"/>
+<img class="img-responsive" src="https://www.redox-os.org/img/hardware/asus-eepc-900.png"/>
 
 Redox running on Panasonic Toughbook CF-18:
 
-<img class="img-responsive" src="http://www.redox-os.org/img/hardware/panasonic-toughbook-cf18.png"/>
+<img class="img-responsive" src="https://www.redox-os.org/img/hardware/panasonic-toughbook-cf18.png"/>
 
 RustType running on Redox:
 
@@ -134,11 +134,11 @@ The above pictures are all real.
 1. [The Glorious Book](https://doc.redox-os.org/book/)
 2. [The Holiest Forum](https://discourse.redox-os.org/)
 3. [The Shiny ISOs](https://static.redox-os.org/)
-4. [Redocs](http://www.redox-os.org/docs/)
+4. [Redocs](https://www.redox-os.org/docs/)
 5. [Fancy GitHub organization](https://github.com/redox-os)
-6. [Our Holy Grail of a Website](http://www.redox-os.org/)
-7. [Our Nice Code of Conduct](http://www.redox-os.org/coc/)
-8. [The Extreme Screenshots](http://www.redox-os.org/screens/)
+6. [Our Holy Grail of a Website](https://www.redox-os.org/)
+7. [Our Nice Code of Conduct](https://www.redox-os.org/coc/)
+8. [The Extreme Screenshots](https://www.redox-os.org/screens/)
 
 # What's next?
 

--- a/content/news/this-week-in-redox-14.md
+++ b/content/news/this-week-in-redox-14.md
@@ -57,26 +57,26 @@ If you have any questions, ideas, or are curious about Redox, we recommend joini
 
 Redox running on Thinkpad T-420:
 
-<img class="img-responsive" src="http://www.redox-os.org/img/hardware/thinkpad-t420.png"/>
+<img class="img-responsive" src="https://www.redox-os.org/img/hardware/thinkpad-t420.png"/>
 
 Redox running on ASUS eeePC 900:
 
-<img class="img-responsive" src="http://www.redox-os.org/img/hardware/asus-eepc-900.png"/>
+<img class="img-responsive" src="https://www.redox-os.org/img/hardware/asus-eepc-900.png"/>
 
 Redox running on Panasonic Toughbook CF-18:
 
-<img class="img-responsive" src="http://www.redox-os.org/img/hardware/panasonic-toughbook-cf18.png"/>
+<img class="img-responsive" src="https://www.redox-os.org/img/hardware/panasonic-toughbook-cf18.png"/>
 
 # Handy links
 
 1. [The Glorious Book](https://doc.redox-os.org/book/)
 2. [The Holiest Forum](https://discourse.redox-os.org/)
 3. [The Shiny ISOs](https://static.redox-os.org/)
-4. [Redocs](http://www.redox-os.org/docs/)
+4. [Redocs](https://www.redox-os.org/docs/)
 5. [Fancy GitHub organization](https://github.com/redox-os)
-6. [Our Holy Grail of a Website](http://www.redox-os.org/)
-7. [Our Nice Code of Conduct](http://www.redox-os.org/coc/)
-8. [The Extreme Screenshots](http://www.redox-os.org/screens/)
+6. [Our Holy Grail of a Website](https://www.redox-os.org/)
+7. [Our Nice Code of Conduct](https://www.redox-os.org/coc/)
+8. [The Extreme Screenshots](https://www.redox-os.org/screens/)
 
 # What's next?
 

--- a/content/news/this-week-in-redox-20.md
+++ b/content/news/this-week-in-redox-20.md
@@ -27,7 +27,7 @@ If you have any questions, ideas, or are curious about Redox, we recommend joini
 - [@pi-pi3](https://github.com/pi-pi3) has improved the performance of `memcpy()` family of functions.
 
 - [@CWood1](https://github.com/CWood1) has been working on adding AML support for the ACPI subsystem.
- 
+
 - [@InsidiousMind](https://github.com/InsidiousMind) did some work on the PIT (Programmable interval timer). Now the PIT interrupt properly context switches fixing crashes in the kernel.
 
 - [@bjorn3](https://github.com/bjorn3) added support for listing all schemes using the `:` scheme.
@@ -37,9 +37,9 @@ If you have any questions, ideas, or are curious about Redox, we recommend joini
 There has been so much work [ion shell](https://github.com/redox-os/ion) that we have it's own section for this issue. Ion is a shell for UNIX platforms, and is the default shell in Redox. It is still a work in progress, but much of the core functionality is complete. It is also currently significantly faster than Bash, and even Dash, making it the fastest system shell to date.
 
 - [@ids1024](https://github.com/ids1024) has been working on Redox's Newlib's [fork](https://github.com/redox-os/newlib). Adding support for getuid(), getgid(), getcwd(), fixed execve() and many others.
- 
+
 - [@jFransham](https://github.com/jFransham) landed a patch enabling LTO which yields a ~15% speedup. Details [here](https://github.com/redox-os/ion/pull/278).
- 
+
 - [@jFransham](https://github.com/jFransham) reduced the number of allocations. Details [here](https://github.com/redox-os/ion/pull/271).
 
 - [@Maaarcocr](https://github.com/Maaarcocr) added descriptions to functions.  Details [here](https://github.com/redox-os/ion/pull/268).
@@ -54,13 +54,13 @@ There has been so much work [ion shell](https://github.com/redox-os/ion) that we
 
 - [@mmstick](https://github.com/mmstick) implemented basic arithmetic for let/export in. Details [here](https://github.com/redox-os/ion/pull/237).
 
-- [@mmstick](https://github.com/mmstick) reworked the while loops and they now work as they do in other shells . Details [here](https://github.com/redox-os/ion/pull/235). 
+- [@mmstick](https://github.com/mmstick) reworked the while loops and they now work as they do in other shells . Details [here](https://github.com/redox-os/ion/pull/235).
 
-- [@mmstick](https://github.com/mmstick) implemented the `&&` and `||`  operators. Details [here](https://github.com/redox-os/ion/pull/227).  
+- [@mmstick](https://github.com/mmstick) implemented the `&&` and `||`  operators. Details [here](https://github.com/redox-os/ion/pull/227).
 
-- [@mmstick](https://github.com/mmstick) implement aliasing support. Details [here](https://github.com/redox-os/ion/pull/222).  
+- [@mmstick](https://github.com/mmstick) implement aliasing support. Details [here](https://github.com/redox-os/ion/pull/222).
 
-- [@mmstick](https://github.com/mmstick) added the ability to pass variables into subshells by expanding inner variables before performing process expansion. Details [here](https://github.com/redox-os/ion/pull/221).  
+- [@mmstick](https://github.com/mmstick) added the ability to pass variables into subshells by expanding inner variables before performing process expansion. Details [here](https://github.com/redox-os/ion/pull/221).
 
 - [@mmstick](https://github.com/mmstick) refactored the parser and also added process recursion. Details [here](https://github.com/redox-os/ion/pull/219).
 
@@ -108,7 +108,7 @@ First of all: Great news! [@ticki](https://github.com/ticki) has been working on
 - [lz4](https://github.com/redox-os/tfs/tree/master/lz4) - An implementation of lz4.
 - [speck](https://github.com/redox-os/tfs/tree/master/speck) - An implementation of SPECK cipher.
 - [tm](https://github.com/redox-os/tfs/tree/master/tm) - transactional memory.
-- [atomic-hashmap](https://github.com/redox-os/tfs/tree/master/atomic-hashmap) - Atomic hashmaps (you can read the [blog post](http://ticki.github.io/blog/an-atomic-hash-table/)).
+- [atomic-hashmap](https://github.com/redox-os/tfs/tree/master/atomic-hashmap) - Atomic hashmaps (you can read the [blog post](https://ticki.github.io/blog/an-atomic-hash-table/)).
 - [mlcr](https://github.com/redox-os/tfs/tree/master/mlcr) - A machine-learning based cache replacement strategy.
 - [seahash](https://github.com/redox-os/tfs/tree/master/seahash) - A hash function.
 - [concurrent](https://github.com/redox-os/tfs/tree/master/concurrent) - Hazard pointers implementation.
@@ -137,10 +137,10 @@ There has been a ton of work on this topic specially on the [pkgutils](https://g
 1. [The Glorious Book](https://doc.redox-os.org/book/)
 2. [The Holiest Forum](https://discourse.redox-os.org/)
 3. [The Shiny ISOs](https://github.com/redox-os/redox/releases)
-4. [Redocs](http://www.redox-os.org/docs/)
+4. [Redocs](https://www.redox-os.org/docs/)
 5. [Fancy GitHub organization](https://github.com/redox-os)
-6. [Our Holy Grail of a Website](http://www.redox-os.org/)
-7. [The Extreme Screenshots](http://www.redox-os.org/screens/)
+6. [Our Holy Grail of a Website](https://www.redox-os.org/)
+7. [The Extreme Screenshots](https://www.redox-os.org/screens/)
 
 # New contributors
 

--- a/content/news/this-week-in-redox-21.md
+++ b/content/news/this-week-in-redox-21.md
@@ -66,10 +66,10 @@ Work on this topic continues specially on the [cookbook](https://github.com/redo
 1. [The Glorious Book](https://doc.redox-os.org/book/)
 2. [The Holiest Forum](https://discourse.redox-os.org/)
 3. [The Shiny ISOs](https://github.com/redox-os/redox/releases)
-4. [Redocs](http://www.redox-os.org/docs/)
+4. [Redocs](https://www.redox-os.org/docs/)
 5. [Fancy GitHub organization](https://github.com/redox-os)
-6. [Our Holy Grail of a Website](http://www.redox-os.org/)
-7. [The Extreme Screenshots](http://www.redox-os.org/screens/)
+6. [Our Holy Grail of a Website](https://www.redox-os.org/)
+7. [The Extreme Screenshots](https://www.redox-os.org/screens/)
 
 # New contributors
 

--- a/content/news/this-week-in-redox-22.md
+++ b/content/news/this-week-in-redox-22.md
@@ -67,10 +67,10 @@ Work on this topic continues specially on the [cookbook](https://github.com/redo
 1. [The Glorious Book](https://doc.redox-os.org/book/)
 2. [The Holiest Forum](https://discourse.redox-os.org/)
 3. [The Shiny ISOs](https://github.com/redox-os/redox/releases)
-4. [Redocs](http://www.redox-os.org/docs/)
+4. [Redocs](https://www.redox-os.org/docs/)
 5. [Fancy GitHub organization](https://github.com/redox-os)
-6. [Our Holy Grail of a Website](http://www.redox-os.org/)
-7. [The Extreme Screenshots](http://www.redox-os.org/screens/)
+6. [Our Holy Grail of a Website](https://www.redox-os.org/)
+7. [The Extreme Screenshots](https://www.redox-os.org/screens/)
 
 # New contributors
 

--- a/content/news/this-week-in-redox-23.md
+++ b/content/news/this-week-in-redox-23.md
@@ -130,10 +130,10 @@ The [pkgutils](https://github.com/redox-os/cookbook) are a set of utilities for 
 1. [The Glorious Book](https://doc.redox-os.org/book/)
 2. [The Holiest Forum](https://discourse.redox-os.org/)
 3. [The Shiny ISOs](https://github.com/redox-os/redox/releases)
-4. [Redocs](http://www.redox-os.org/docs/)
+4. [Redocs](https://www.redox-os.org/docs/)
 5. [Fancy GitHub organization](https://github.com/redox-os)
-6. [Our Holy Grail of a Website](http://www.redox-os.org/)
-7. [The Extreme Screenshots](http://www.redox-os.org/screens/)
+6. [Our Holy Grail of a Website](https://www.redox-os.org/)
+7. [The Extreme Screenshots](https://www.redox-os.org/screens/)
 
 # New contributors
 

--- a/content/news/this-week-in-redox-24.md
+++ b/content/news/this-week-in-redox-24.md
@@ -124,10 +124,10 @@ The [pkgutils](https://github.com/redox-os/cookbook) are a set of utilities for 
 1. [The Glorious Book](https://doc.redox-os.org/book/)
 2. [The Holiest Forum](https://discourse.redox-os.org/)
 3. [The Shiny ISOs](https://github.com/redox-os/redox/releases)
-4. [Redocs](http://www.redox-os.org/docs/)
+4. [Redocs](https://www.redox-os.org/docs/)
 5. [Fancy GitHub organization](https://github.com/redox-os)
-6. [Our Holy Grail of a Website](http://www.redox-os.org/)
-7. [The Extreme Screenshots](http://www.redox-os.org/screens/)
+6. [Our Holy Grail of a Website](https://www.redox-os.org/)
+7. [The Extreme Screenshots](https://www.redox-os.org/screens/)
 
 # New contributors
 

--- a/content/news/this-week-in-redox-25.md
+++ b/content/news/this-week-in-redox-25.md
@@ -20,13 +20,13 @@ Big news this week: We released **0.3.0**.It is a big release including many imp
 
 Now to this weeks summary: We shipped a couple of changes to the bootstrap script and the cookbook that should make the on-boarding on macOS smooth again. Go ahead try and give us feedback <3.
 
-The **kernel** was very active this week, particularly with the landing of the initial support for signals by [@jackpot51](https://github.com/jackpot51)! Also, a new API for specifying custom memory allocators and changes in the `alloc` crate API landed in nightly so the kernel had to be updated. Mr [@CWood1](https://github.com/CWood1) added an HPET (High Precision Event Time) driver to the kernel and also moved the PIT (Programmable Interval Timer) driver from the bootloader to the kernel as part of his ongoing work on ACPI. [@ids1024](https://github.com/ids1024) shipped some fixes to kernel's `dup2()` and `exec()` too. 
+The **kernel** was very active this week, particularly with the landing of the initial support for signals by [@jackpot51](https://github.com/jackpot51)! Also, a new API for specifying custom memory allocators and changes in the `alloc` crate API landed in nightly so the kernel had to be updated. Mr [@CWood1](https://github.com/CWood1) added an HPET (High Precision Event Time) driver to the kernel and also moved the PIT (Programmable Interval Timer) driver from the bootloader to the kernel as part of his ongoing work on ACPI. [@ids1024](https://github.com/ids1024) shipped some fixes to kernel's `dup2()` and `exec()` too.
 
-**Ion** impressive streak continues mainly propelled (but no limited to) by  [@mmstick](https://github.com/mmstick) and [@huntergoldstein](https://github.com/huntergoldstein). **Ion**'s biggest highlight this week? The completion of job control and addition of the `fg` builtin command! Also asynchronous history writing, the addition of an `array!` macro to ease the creation of  inline `Array`s in Ion's codebase, initial support for herestrings, the extraction of `calc` to it's own crate, refactoring to signal handling, forking, the reimplementation of `pipelines::collect` into a recursive descendent parser, `set -x`'s implementation and many fixes. You should try it , works in Linux too ;).  
+**Ion** impressive streak continues mainly propelled (but no limited to) by  [@mmstick](https://github.com/mmstick) and [@huntergoldstein](https://github.com/huntergoldstein). **Ion**'s biggest highlight this week? The completion of job control and addition of the `fg` builtin command! Also asynchronous history writing, the addition of an `array!` macro to ease the creation of  inline `Array`s in Ion's codebase, initial support for herestrings, the extraction of `calc` to it's own crate, refactoring to signal handling, forking, the reimplementation of `pipelines::collect` into a recursive descendent parser, `set -x`'s implementation and many fixes. You should try it , works in Linux too ;).
 
 **Drivers** had to also be updated to the new `alloc` API (mainly `vesad`). **Coreutils** now have a `base64` command by  [@goyox86](https://github.com/goyox86), a new shiny `dirname` command along with recent support for `rm` for the `-f` flag thanks to [@ids1024](https://github.com/ids1024).
 
-Other important highlight is the addition of initial `mtime/ctime` support and the implementation of `futimens` in **Redoxfs**. 
+Other important highlight is the addition of initial `mtime/ctime` support and the implementation of `futimens` in **Redoxfs**.
 
 Last but not least the **cookbook** saw a lot of activity with a new system for compile-time dependencies by [@ids1024](https://github.com/ids1024) and package recipes for `git`, `gawk`, `findutils`, GNU `sed`, `pastel`, `nasm`, `rustual-boy`.
 
@@ -114,18 +114,18 @@ The [cookbook](https://github.com/redox-os/cookbook) the collection of package r
 - [@goyox86](https://github.com/goyox86) Added some code in the cookbook system to determine tools at runtime and fix macOS build. Details [here](https://github.com/redox-os/cookbook/pull/47).
 - [@ids1024](https://github.com/ids1024) Added a recipe for GNU `sed`. Details [here](https://github.com/redox-os/cookbook/pull/48).
 - [@ids1024](https://github.com/ids1024) Added a recipe for uutils `findutils`. Details [here](https://github.com/redox-os/cookbook/pull/49).
-- [@jackpot51](https://github.com/jackpot51) Add a recipe for `pastel`. Details [here](https://github.com/redox-os/cookbook/commit/5b78bf1d6c134cd6a2f23ed4fbd935ea9610c26a). 
-- [@7h0ma5](https://github.com/7h0ma5)  Added a recipe for `nasm`. Details [here](https://github.com/redox-os/cookbook/pull/42). 
+- [@jackpot51](https://github.com/jackpot51) Add a recipe for `pastel`. Details [here](https://github.com/redox-os/cookbook/commit/5b78bf1d6c134cd6a2f23ed4fbd935ea9610c26a).
+- [@7h0ma5](https://github.com/7h0ma5)  Added a recipe for `nasm`. Details [here](https://github.com/redox-os/cookbook/pull/42).
 
 # Handy links
 
 1. [The Glorious Book](https://doc.redox-os.org/book/)
 2. [The Holiest Forum](https://discourse.redox-os.org/)
 3. [The Shiny ISOs](https://github.com/redox-os/redox/releases)
-4. [Redocs](http://www.redox-os.org/docs/)
+4. [Redocs](https://www.redox-os.org/docs/)
 5. [Fancy GitHub organization](https://github.com/redox-os)
-6. [Our Holy Grail of a Website](http://www.redox-os.org/)
-7. [The Extreme Screenshots](http://www.redox-os.org/screens/)
+6. [Our Holy Grail of a Website](https://www.redox-os.org/)
+7. [The Extreme Screenshots](https://www.redox-os.org/screens/)
 
 # New contributors
 
@@ -135,5 +135,5 @@ Sorted in alphabetical order.
 
 - Luca Weiss 🎂
 - Thomas Gatzweiler 🎂
- 
+
 If I missed something, feel free to contact me (goyox86) or send a PR to [Redox website](https://github.com/redox-os/website).

--- a/content/news/this-week-in-redox-26.md
+++ b/content/news/this-week-in-redox-26.md
@@ -169,10 +169,10 @@ The [cookbook](https://github.com/redox-os/cookbook) the collection of package r
 1. [The Glorious Book](https://doc.redox-os.org/book/)
 2. [The Holiest Forum](https://discourse.redox-os.org/)
 3. [The Shiny ISOs](https://github.com/redox-os/redox/releases)
-4. [Redocs](http://www.redox-os.org/docs/)
+4. [Redocs](https://www.redox-os.org/docs/)
 5. [Fancy GitHub organization](https://github.com/redox-os)
-6. [Our Holy Grail of a Website](http://www.redox-os.org/)
-7. [The Extreme Screenshots](http://www.redox-os.org/screens/)
+6. [Our Holy Grail of a Website](https://www.redox-os.org/)
+7. [The Extreme Screenshots](https://www.redox-os.org/screens/)
 
 # New contributors
 

--- a/content/news/this-week-in-redox-27.md
+++ b/content/news/this-week-in-redox-27.md
@@ -22,7 +22,7 @@ As always, we have a bunch of good news to share with you. So lets get the ball 
 
 This week, one of the biggest changes is that we started to track the `Cargo.lock` file of most of Redox crates in Git as an attempt to improve the reproducibility of builds.
 
-[@jackpot51](https://github.com/jackpot51) did a bunch of work in the **kernel** in order to add support for process groups. Result: as of this week, you can send signals to process groups! 
+[@jackpot51](https://github.com/jackpot51) did a bunch of work in the **kernel** in order to add support for process groups. Result: as of this week, you can send signals to process groups!
 
 There was a also a small change on the **kernel** making an error to pass an non-empty buffer to `dup` in schemes, basically, after this change you will get `EINVAL` if you do so. [@jackpot51](https://github.com/jackpot51) also prevented handling of nested signals.
 
@@ -34,21 +34,21 @@ The XHCI **driver** got a lot of love by [@jackpot51](https://github.com/jackpot
 
 **Redoxfs** saw the birth of directory symbolic links, a fix for `readdir` when directories don't fit in the buffer and a FUSE update allowing setting `mtime` to earlier times. All of those by [@ids1024](https://github.com/ids1024).
 
-On the **TFS** department we have for the first time in a while new contributors! This work includes [@m4b](https://github.com/m4b)'s  usage of `debug_map` in `chashmap` enabling maps pretty printing, [@cedenday](https://github.com/cedenday)'s remotion of `speck`s dependency on `std` and the fix for an infinite loop in `chashmap`'s `scan()` by [@memoryleak47](https://github.com/memoryleak47). Well done people! 
+On the **TFS** department we have for the first time in a while new contributors! This work includes [@m4b](https://github.com/m4b)'s  usage of `debug_map` in `chashmap` enabling maps pretty printing, [@cedenday](https://github.com/cedenday)'s remotion of `speck`s dependency on `std` and the fix for an infinite loop in `chashmap`'s `scan()` by [@memoryleak47](https://github.com/memoryleak47). Well done people!
 
 [@ticki](https://github.com/ticki) continues improving **TFS**'s
 test suite along with an interesting work in reserving reserved special pointers for `conc::hazard::State` to avoid overlapping with pointers used in `Protect`. Also, if you are an compression algorithm aficionado you might want to look at [@ticki](https://github.com/ticki)'s [notes](https://github.com/redox-os/tfs/commit/624dce5fc4e12063972bc4817edfacfaa558f333) on `zmicro`, as they were updated this week.
 
-In **coreutils** land [@ids1024](https://github.com/ids1024) allowed directory as second argument to `ln` and implemented octal escapes in `tr`. 
+In **coreutils** land [@ids1024](https://github.com/ids1024) allowed directory as second argument to `ln` and implemented octal escapes in `tr`.
 
 Continuing his last week's work on **userutils** [@goyox86](https://github.com/goyox86) made revisions to `getty`, `passwd`, `login` and `su` in order to update them to `coreutils` conventions and new APIs while Mr [@jackpot51](https://github.com/jackpot51) made updates to `getty` in order to use `PTY` to provide line control for raw consoles and `vesad`.
 
-We end this week's tour on the **cookbook**  which saw the addition of a `status.sh` script for checking git modifications, an `update.sh` one to, well, update everything and the corresponding updates to `cook.sh` caused by `Cargo.lock` being now tracked in version control. All of that by [@jackpot51](https://github.com/jackpot51). 
+We end this week's tour on the **cookbook**  which saw the addition of a `status.sh` script for checking git modifications, an `update.sh` one to, well, update everything and the corresponding updates to `cook.sh` caused by `Cargo.lock` being now tracked in version control. All of that by [@jackpot51](https://github.com/jackpot51).
 
 [@ids1024](https://github.com/ids1024) added recipes for GNU `grep`, `diffutils` and made a patch in the `git` recipe to use `;` as `PATH` separator.
 
 Enjoy the rest, and see you next week!
- 
+
 ## Kernel
 
 - [@jackpot51](https://github.com/jackpot51) Made changes to make an error to supply a `dup` buffer to schemes that do not handle it. Details [here](https://github.com/redox-os/kernel/commit/fc914e0cae8c865ed260af7286314c7dc8e63f19) and [here](https://github.com/redox-os/kernel/commit/6a061665e47febfff53e356363cfb7c13873dbec).
@@ -71,7 +71,7 @@ Enjoy the rest, and see you next week!
 - [@huntergoldstein](https://github.com/huntergoldstein) Made a fix to ignore `SIGTTOU` before setting process group. Details [here](https://github.com/redox-os/ion/pull/462).
 - [@bb010g](https://github.com/bb010g) Moved OS #[cfg] functions to `sys`. Details [here](https://github.com/redox-os/ion/pull/464).
 - [@bblancha](https://github.com/bblancha) Implemented a simple form of associative arrays. Details [here](https://github.com/redox-os/ion/pull/465).
-- [@llambda](https://github.com/llambda) Made `Ion` compile on Darwin. Details [here](https://github.com/redox-os/ion/pull/466). 
+- [@llambda](https://github.com/llambda) Made `Ion` compile on Darwin. Details [here](https://github.com/redox-os/ion/pull/466).
 - [@fengalin](https://github.com/fengalin) Fixed the compilation on Redox. Details [here](https://github.com/redox-os/ion/pull/467).
 - [@nivkner](https://github.com/nivkner) Included whitespace in `alias` builtin arguments. Details [here](https://github.com/redox-os/ion/pull/468).
 - [@memoryleak47](https://github.com/memoryleak47) Implemented `popd` command line options. Details [here](https://github.com/redox-os/ion/pull/473).
@@ -171,10 +171,10 @@ The [cookbook](https://github.com/redox-os/cookbook) the collection of package r
 1. [The Glorious Book](https://doc.redox-os.org/book/)
 2. [The Holiest Forum](https://discourse.redox-os.org/)
 3. [The Shiny ISOs](https://github.com/redox-os/redox/releases)
-4. [Redocs](http://www.redox-os.org/docs/)
+4. [Redocs](https://www.redox-os.org/docs/)
 5. [Fancy GitHub organization](https://github.com/redox-os)
-6. [Our Holy Grail of a Website](http://www.redox-os.org/)
-7. [The Extreme Screenshots](http://www.redox-os.org/screens/)
+6. [Our Holy Grail of a Website](https://www.redox-os.org/)
+7. [The Extreme Screenshots](https://www.redox-os.org/screens/)
 
 # New contributors
 

--- a/content/news/this-week-in-redox-28.md
+++ b/content/news/this-week-in-redox-28.md
@@ -28,7 +28,7 @@ On **drivers** land, the star of this week is the work being done by [@jackpot51
 
 Next stop is **Redoxfs**, where [@jackpot51](https://github.com/jackpot51) and [@ids1024](https://github.com/ids1024) enabled deallocating on resizing and fixed a freeze caused by a double lock respectively.
 
-**TFS** folks where also very busy these last weeks! Notably [@ticki](https://github.com/ticki) who published a [blog post](http://ticki.github.io/blog/fearless-concurrency-with-hazard-pointers/) about the new shiny [conc](https://crates.io/crates/conc) crate which uses hazard pointers instead of epochs for doing concurrent memory reclamation. [@ticki](https://github.com/ticki) was also busy improving the documentation of the `conc` crate, rewriting `conc::sync::treiber` and adding `conc::Guard::{try,maybe}_map` while [@cedenday](https://github.com/cedenday) added a few trait derivations to `speck`'s `Key`.
+**TFS** folks where also very busy these last weeks! Notably [@ticki](https://github.com/ticki) who published a [blog post](https://ticki.github.io/blog/fearless-concurrency-with-hazard-pointers/) about the new shiny [conc](https://crates.io/crates/conc) crate which uses hazard pointers instead of epochs for doing concurrent memory reclamation. [@ticki](https://github.com/ticki) was also busy improving the documentation of the `conc` crate, rewriting `conc::sync::treiber` and adding `conc::Guard::{try,maybe}_map` while [@cedenday](https://github.com/cedenday) added a few trait derivations to `speck`'s `Key`.
 
 [@Abogical](https://github.com/Abogical) added the `whois` utility to **Netutils** and [@ids1024](https://github.com/ids1024) added `gzip` and `xz` extraction support to **extrautils**'s `tar`.
 
@@ -112,7 +112,7 @@ Enjoy the rest of this weeks issue!
 
 [TFS](https://github.com/redox-os/tfs) is a modular, fast, and feature rich next-gen file system, employing modern techniques for high performance, high space efficiency, and high scalability.
 
-- [@ticki](https://github.com/ticki) Published a new blog "Fearless concurrency with hazard pointers" about the new shiny [conc](https://crates.io/crates/conc) crate. Details [here](http://ticki.github.io/blog/fearless-concurrency-with-hazard-pointers/).
+- [@ticki](https://github.com/ticki) Published a new blog "Fearless concurrency with hazard pointers" about the new shiny [conc](https://crates.io/crates/conc) crate. Details [here](https://ticki.github.io/blog/fearless-concurrency-with-hazard-pointers/).
 - [@ticki](https://github.com/ticki) Fixed some compile errors in `atomic-hashmap`. Details [here](https://github.com/redox-os/tfs/commit/7118c7bf135647a3e452831e2836b6df79326d4e).
 - [@ticki](https://github.com/ticki) Fix documentation for wrong use of `Guard::new`. Details [here](https://github.com/redox-os/tfs/commit/f8a080e4415982b34f34a30235b2bb91d42b8450).
 - [@ticki](https://github.com/ticki) Improved documentation of `atomic-hashmap`. Details [here](https://github.com/redox-os/tfs/commit/27b8c62e29f718347dacd6d44c4add6dfa9f4d74).
@@ -185,10 +185,10 @@ The [cookbook](https://github.com/redox-os/cookbook) the collection of package r
 1. [The Glorious Book](https://doc.redox-os.org/book/)
 2. [The Holiest Forum](https://discourse.redox-os.org/)
 3. [The Shiny ISOs](https://github.com/redox-os/redox/releases)
-4. [Redocs](http://www.redox-os.org/docs/)
+4. [Redocs](https://www.redox-os.org/docs/)
 5. [Fancy GitHub organization](https://github.com/redox-os)
-6. [Our Holy Grail of a Website](http://www.redox-os.org/)
-7. [The Extreme Screenshots](http://www.redox-os.org/screens/)
+6. [Our Holy Grail of a Website](https://www.redox-os.org/)
+7. [The Extreme Screenshots](https://www.redox-os.org/screens/)
 
 # New contributors
 

--- a/content/news/this-week-in-redox-29.md
+++ b/content/news/this-week-in-redox-29.md
@@ -26,7 +26,7 @@ There is a lot of stuff packed on this one. So... Buckle up!
 
 First things first: During my absence there were 3 new releases [0.3.1](https://github.com/redox-os/redox/releases/tag/0.3.1), [0.3.2](https://github.com/redox-os/redox/releases/tag/0.3.2) and [0.3.3](https://github.com/redox-os/redox/releases/tag/0.3.3) focused on better POSIX compatibility, improved ACPI support and lower memory usage respectively (Along many other things I'm gonna cover next).
 
-We also have a new [login window and a file dialog](https://imgur.com/a/4E7sz) thanks to [@jackpot51](https://github.com/jackpot51). 
+We also have a new [login window and a file dialog](https://imgur.com/a/4E7sz) thanks to [@jackpot51](https://github.com/jackpot51).
 
 Other important news is that we are now maintaining the **RustType** crate, which can be found [here](https://github.com/redox-os/rusttype), under the redox-os Github organization.
 
@@ -40,7 +40,7 @@ The **RedoxFS** got some attention from [@ids1024](https://github.com/ids1024) w
 
 **TFS** land was visited by [@ticki](https://github.com/ticki) and among the highlights are: the introduction of a new `control-flow` crate to control control-flow outside closures, a fix for several compile errors in `atomic-hashmap`, the addition of `conc::Guard::{try,maybe}_map` followed by the switch to `parking_lot` in `conc`.
 
-The **cookbook** (our collection of packages) was also very active during this period! [@7h0ma5](https://github.com/7h0ma5) added recipes for `ncurses` and `readline` while [@ids1024](https://github.com/ids1024) added one for `perl` and [@xTibor](https://github.com/xTibor) added `ffmpeg`. `python` was updated to a new version and a new `--debug` argument was added to `cook.sh` (the package builder). Last but no least! [@AgostonSzepessy](https://github.com/AgostonSzepessy) added support for dependency info to packages. Nice! 
+The **cookbook** (our collection of packages) was also very active during this period! [@7h0ma5](https://github.com/7h0ma5) added recipes for `ncurses` and `readline` while [@ids1024](https://github.com/ids1024) added one for `perl` and [@xTibor](https://github.com/xTibor) added `ffmpeg`. `python` was updated to a new version and a new `--debug` argument was added to `cook.sh` (the package builder). Last but no least! [@AgostonSzepessy](https://github.com/AgostonSzepessy) added support for dependency info to packages. Nice!
 
 Also, there are big news in **coreutils**: We are now using [coreutils](https://github.com/uutils/coreutils) versions of the utilities where it makes sense. For example: [@ids1024](https://github.com/ids1024) removed our versions of `chmod`, `env`, and `ls` opening room for the better versions on `uutils` (our fork of `coreutils`). While all of that was being done, [@dabbydubby](https://github.com/dabbydubby) was improving `pwd`'s description, reformatting, restructuring and fixing few bugs in `mv` and afterwhile porting those changes over to `cp`.
 
@@ -48,7 +48,7 @@ Finally on the GUI side of things **Orbital** experienced bunch of unused code r
 
 *Bonus*: Few days ago we saw this message from [@jackpot51](https://github.com/jackpot51) on the Redox chat: "Gentlemen, I am going to port libservo". Yes! some `libservo` work is on the way <3
 
-*Bonus 2*: I also woke up one day and saw this [MESA fork](https://github.com/redox-os/mesa). 
+*Bonus 2*: I also woke up one day and saw this [MESA fork](https://github.com/redox-os/mesa).
 
 Exciting times! Aren't they? Stay tunned for more!
 
@@ -282,10 +282,10 @@ The Orbital Widget Toolkit. Compatible with Redox and SDL2.
 1. [The Glorious Book](https://doc.redox-os.org/book/)
 2. [The Holiest Forum](https://discourse.redox-os.org/)
 3. [The Shiny ISOs](https://github.com/redox-os/redox/releases)
-4. [Redocs](http://www.redox-os.org/docs/)
+4. [Redocs](https://www.redox-os.org/docs/)
 5. [Fancy GitHub organization](https://github.com/redox-os)
-6. [Our Holy Grail of a Website](http://www.redox-os.org/)
-7. [The Extreme Screenshots](http://www.redox-os.org/screens/)
+6. [Our Holy Grail of a Website](https://www.redox-os.org/)
+7. [The Extreme Screenshots](https://www.redox-os.org/screens/)
 
 # New contributors
 

--- a/content/news/this-week-in-redox-30.md
+++ b/content/news/this-week-in-redox-30.md
@@ -16,13 +16,13 @@ If you have any questions, ideas, or are curious about Redox, we recommend joini
 
 ## TL;DR
 
-Hello there! And welcome to another edition of TWiR! 
+Hello there! And welcome to another edition of TWiR!
 
 As usual, we have been busy making Redox better and we have a couple of exciting news to share. So, Let's get started!
 
 First of all, [@andre](https://github.com/andre-richter) pointed out that the Docker experience has been improved. Among others, consecutive builds are now way faster because `cargo` downloads are cached with named volumes. Also, there's documentation for running the container interactively now. Please check it out [here](https://github.com/redox-os/redox/blob/master/docker/README.md)!
 
-We are super excited about the work done by [@jackpot51](https://github.com/jackpot51) towards the installer support. For example, the **bootloader** now supports filesystem UUID detection and is able to send that information to the kernel at boot time. The **kernel** has notably gained the ability to receive environment variables at the main entry point (`kmain`) this is needed to being able to receive that `REDOXFS_UUID` environment with the filesystem UUID to be mounted. It's also worth mentioning that [@jackpot51](https://github.com/jackpot51) made some refactoring to the **kernel** arguments infrastructure. 
+We are super excited about the work done by [@jackpot51](https://github.com/jackpot51) towards the installer support. For example, the **bootloader** now supports filesystem UUID detection and is able to send that information to the kernel at boot time. The **kernel** has notably gained the ability to receive environment variables at the main entry point (`kmain`) this is needed to being able to receive that `REDOXFS_UUID` environment with the filesystem UUID to be mounted. It's also worth mentioning that [@jackpot51](https://github.com/jackpot51) made some refactoring to the **kernel** arguments infrastructure.
 
 The other very important change is related to schemes. Redox now supports hierarchical schemes enabling for example, more than one disk controller.
 
@@ -180,13 +180,13 @@ The Redox coreutils.
 1. [The Glorious Book](https://doc.redox-os.org/book/)
 2. [The Holiest Forum](https://discourse.redox-os.org/)
 3. [The Shiny ISOs](https://github.com/redox-os/redox/releases)
-4. [Redocs](http://www.redox-os.org/docs/)
+4. [Redocs](https://www.redox-os.org/docs/)
 5. [Fancy GitHub organization](https://github.com/redox-os)
-6. [Our Holy Grail of a Website](http://www.redox-os.org/)
-7. [The Extreme Screenshots](http://www.redox-os.org/screens/)
+6. [Our Holy Grail of a Website](https://www.redox-os.org/)
+7. [The Extreme Screenshots](https://www.redox-os.org/screens/)
 
 # New contributors
- 
+
 Since the list of contributors are growing too fast, we'll now only list the new contributors. This might change in the future.
 
 Sorted in alphabetical order.

--- a/content/news/this-week-in-redox-31.md
+++ b/content/news/this-week-in-redox-31.md
@@ -18,11 +18,11 @@ Don't forget that if you would like to see any package ported to Redox or are wo
 
 ## TL;DR
 
-Hello and welcome to another issue of This Week in Redox! 
+Hello and welcome to another issue of This Week in Redox!
 
-The Last two weeks we have been busy working on some cool and exciting stuff! 
+The Last two weeks we have been busy working on some cool and exciting stuff!
 
-Let's start with the no-so-exciting things. That is: **bootloader** and **drivers** got their LICENSE file. 
+Let's start with the no-so-exciting things. That is: **bootloader** and **drivers** got their LICENSE file.
 
 Moving on to the super exciting territory we have [@jackpot51](https://github.com/jackpot51) (who else!?), who has been pretty busy standing on [@ids1024](https://github.com/ids1024)'s shoulders and his GSoC work on self hosting. He has been implementing the remaining tasks and fixing the outstanding issues preventing us to run `rustc` and `cargo` inside Redox. This is a big deal! As is the crucial step on making Redox OS self hosted.
 
@@ -32,7 +32,7 @@ On the **Ion** side of things (and pretty much as always) we have a ton of stuff
 
 There was lots of activity on the **cookbook** too: The addition of man pages by [@jackpot51](https://github.com/jackpot51), [@NilSet](https://github.com/NilSet) adding a recipe for `PrBoom` (Yes! we *almost* run doom!). Mr [@goyox86](https://github.com/goyox86) adding support for the recently released `fd`, [@sajattack](https://github.com/sajattack) porting `termplay` finishing up with [@xTibor](https://github.com/xTibor) who added a `vttest` recipe.
 
-**Orbterm** saw [@jackpot51](https://github.com/jackpot51) updating `ransid` which improved significantly ANSI compliance. Versions `0.2.0`, `0.2.1` and `0.2.2` were also released while [@xTibor](https://github.com/xTibor) made some updates to use the new `ransid` color handling. 
+**Orbterm** saw [@jackpot51](https://github.com/jackpot51) updating `ransid` which improved significantly ANSI compliance. Versions `0.2.0`, `0.2.1` and `0.2.2` were also released while [@xTibor](https://github.com/xTibor) made some updates to use the new `ransid` color handling.
 
 As mentioned before, **ransid**, our backend for terminal emulators got some love. It's ANSI compliance was improved significantly. Notably, versions `0.3.1`, `0.3.2`, `0.3.3` and `0.3.4` shipped improvements to unknown escapes parsing, corrections on csi handling of missing escapes and fixes for cursor movement csis.
 
@@ -177,13 +177,13 @@ A fork of newlib from git://sourceware.org/git/newlib-cygwin.git with Redox supp
 1. [The Glorious Book](https://doc.redox-os.org/book/)
 2. [The Holiest Forum](https://discourse.redox-os.org/)
 3. [The Shiny ISOs](https://github.com/redox-os/redox/releases)
-4. [Redocs](http://www.redox-os.org/docs/)
+4. [Redocs](https://www.redox-os.org/docs/)
 5. [Fancy GitHub organization](https://github.com/redox-os)
-6. [Our Holy Grail of a Website](http://www.redox-os.org/)
-7. [The Extreme Screenshots](http://www.redox-os.org/screens/)
+6. [Our Holy Grail of a Website](https://www.redox-os.org/)
+7. [The Extreme Screenshots](https://www.redox-os.org/screens/)
 
 # New contributors
- 
+
 Since the list of contributors are growing too fast, we'll now only list the new contributors. This might change in the future.
 
 Sorted in alphabetical order.

--- a/content/news/this-week-in-redox-32.md
+++ b/content/news/this-week-in-redox-32.md
@@ -226,10 +226,10 @@ A fork of newlib from git://sourceware.org/git/newlib-cygwin.git with Redox supp
 1. [The Glorious Book](https://doc.redox-os.org/book/)
 2. [The Holiest Forum](https://discourse.redox-os.org/)
 3. [The Shiny ISOs](https://github.com/redox-os/redox/releases)
-4. [Redocs](http://www.redox-os.org/docs/)
+4. [Redocs](https://www.redox-os.org/docs/)
 5. [Fancy GitHub organization](https://github.com/redox-os)
-6. [Our Holy Grail of a Website](http://www.redox-os.org/)
-7. [The Extreme Screenshots](http://www.redox-os.org/screens/)
+6. [Our Holy Grail of a Website](https://www.redox-os.org/)
+7. [The Extreme Screenshots](https://www.redox-os.org/screens/)
 
 # New contributors
 

--- a/content/news/this-week-in-redox-33.md
+++ b/content/news/this-week-in-redox-33.md
@@ -53,13 +53,13 @@ Also in the GUI department, the **Orbtk** toolkit saw new version `0.2.26` inclu
 
 Next in the queue, is **Orbterm**, the terminal emulator. **Orbterm** released two new versions: `0.3.1` and `0.3.2` with improved resize performance by [@jackpot51](https://github.com/jackpot51) and the extraction of width and heights into fields by [@xTibor](https://github.com/xTibor).
 
-**Sodium**, the text editor got a bit of love from [@sajattack](https://github.com/sajattack) who made a change to infer file to save to from file opened. 
+**Sodium**, the text editor got a bit of love from [@sajattack](https://github.com/sajattack) who made a change to infer file to save to from file opened.
 
 On the utils section, the **userutils** crate was under heavy refactoring and improvement primarily by [@MggMuggins](https://github.com/MggMuggins) who added `groupadd` and `useradd` as well refactored of almost all the rest of the tools. Related to this work is the one done by [@goyox86](https://github.com/goyox86) on the **redox_users** crate improving error handling and propagation by moving it to the `failure` crate. [@MggMuggins](https://github.com/MggMuggins) also extended `redox_users` API with the `add_user`, `add_group` and `get_gid` functions.
 
 The **coreutils** package got lots of attention too. Here [@Mojo4242](https://github.com/Mojo4242) simplified `dd`, [@Tommoa](https://github.com/Tommoa) made some performance improvements for `cat`, while [@jackpot51](https://github.com/jackpot51) was shipping `chown` and using more utilities from `uutils` instead of our own.
 
-Lastly but not least is **extrautils** who experienced a small change to use `cksum` from `uutils`. 
+Lastly but not least is **extrautils** who experienced a small change to use `cksum` from `uutils`.
 
 Phew! That was a lot of work <3
 
@@ -300,13 +300,13 @@ Extra utilities for Redox (and Unix systems).
 1. [The Glorious Book](https://doc.redox-os.org/book/)
 2. [The Holiest Forum](https://discourse.redox-os.org/)
 3. [The Shiny ISOs](https://github.com/redox-os/redox/releases)
-4. [Redocs](http://www.redox-os.org/docs/)
+4. [Redocs](https://www.redox-os.org/docs/)
 5. [Fancy GitHub organization](https://github.com/redox-os)
-6. [Our Holy Grail of a Website](http://www.redox-os.org/)
-7. [The Extreme Screenshots](http://www.redox-os.org/screens/)
+6. [Our Holy Grail of a Website](https://www.redox-os.org/)
+7. [The Extreme Screenshots](https://www.redox-os.org/screens/)
 
 # New contributors
- 
+
 Since the list of contributors are growing too fast, we'll now only list the new contributors. This might change in the future.
 
 Sorted in alphabetical order.

--- a/content/news/this-week-in-redox-34.md
+++ b/content/news/this-week-in-redox-34.md
@@ -23,7 +23,7 @@ The team worked super hard and shipped a ton of interesting stuff! I am preparin
 
 Without further ado, here is what happened this last few weeks:
 
-Big news! We were surprised this week by [@jackpot51](https://github.com/jackpot51) and his news about the plans to create a foundation to support and foster Redox OS and it's ecosystem. This is really good news! More on it on the upcoming issues. 
+Big news! We were surprised this week by [@jackpot51](https://github.com/jackpot51) and his news about the plans to create a foundation to support and foster Redox OS and it's ecosystem. This is really good news! More on it on the upcoming issues.
 
 In the main top-level repo (**redox**) `netdb` (which contains the default `/etc/hosts` and friends) is now included in the filesystem by default. Also, [@jD91mZM2](https://github.com/jD91mZM2) fixed the rust toolchain to `nightly-2017-12-21` as the `ring` does not work with the latest `nightly`.
 
@@ -33,11 +33,11 @@ The `null` and `zero` daemons which implement the `null:` and `zero:` schemes re
 
 As you might suspect, the **syscall** crate the new, shinny `frename` call, <3.
 
-**Redoxfs** got renaming support with the implementation of `frename`. 
+**Redoxfs** got renaming support with the implementation of `frename`.
 
 **Ion**, The Redox (and Linux) shell, saw a lot of activity, notably the addition of the `exec` builtin by [@dlrobertson](https://github.com/dlrobertson), the addition of a title bar setting and the ability to produce any character using hex code by [@jackpot51](https://github.com/jackpot51). [@nihathrael](https://github.com/nihathrael) was busy adding the `@lines()` and `@reverse()` methods while [@mmstick](https://github.com/mmstick) made a change to use a static map for simple color lookups, removed `Shell::update_variables`, added `UID` and `EUID`, added support for enabling forks to ignore streams, fixed `EAGAIN` error on forks and started to work on library/binary separation.
 
-The **cookbook** saw the birth of a `newlib` test suite, packages for the recently moved to userspace `nulld` and `zerod` daemons, some improvements to the `bash` along a fixed the `raw-bin` (which was broken because of the recent changes to `redox_users`'s API).   
+The **cookbook** saw the birth of a `newlib` test suite, packages for the recently moved to userspace `nulld` and `zerod` daemons, some improvements to the `bash` along a fixed the `raw-bin` (which was broken because of the recent changes to `redox_users`'s API).
 
 On the GUI side of things, **Orbtk** the widget toolkit saw a change by [@FloVanGH](https://github.com/FloVanGH) who used `include_bytes!` to load icons on ComboBoxes.
 
@@ -47,9 +47,9 @@ Also UI related, **Orbterm**, the terminal emulator, received an Ion related fix
 
 Finally, in the land of the utils (**coreutils** and **userutils**), there were only two minor changes related to using `unwrap_or_exit` and the new APIs exposed by `redox_users`.
 
-Thanks to all the people who supported the project this year, from the contributors to the patreons, and all the people that spread the word, and the Rust community for creating such an amazing tool, enabling us our ultimate objective: to create a modern, lightweight fast and above all, a safer operating system. 
+Thanks to all the people who supported the project this year, from the contributors to the patreons, and all the people that spread the word, and the Rust community for creating such an amazing tool, enabling us our ultimate objective: to create a modern, lightweight fast and above all, a safer operating system.
 
-See you next year! 
+See you next year!
 
 ## Redox
 
@@ -174,13 +174,13 @@ The Redox coreutils.
 1. [The Glorious Book](https://doc.redox-os.org/book/)
 2. [The Holiest Forum](https://discourse.redox-os.org/)
 3. [The Shiny ISOs](https://github.com/redox-os/redox/releases)
-4. [Redocs](http://www.redox-os.org/docs/)
+4. [Redocs](https://www.redox-os.org/docs/)
 5. [Fancy GitHub organization](https://github.com/redox-os)
-6. [Our Holy Grail of a Website](http://www.redox-os.org/)
-7. [The Extreme Screenshots](http://www.redox-os.org/screens/)
+6. [Our Holy Grail of a Website](https://www.redox-os.org/)
+7. [The Extreme Screenshots](https://www.redox-os.org/screens/)
 
 # New contributors
- 
+
 Since the list of contributors are growing too fast, we'll now only list the new contributors. This might change in the future.
 
 Sorted in alphabetical order.

--- a/content/news/this-week-in-redox-35.md
+++ b/content/news/this-week-in-redox-35.md
@@ -195,10 +195,10 @@ Extra utilities for Redox (and Unix systems).
 1. [The Glorious Book](https://doc.redox-os.org/book/)
 2. [The Holiest Forum](https://discourse.redox-os.org/)
 3. [The Shiny ISOs](https://github.com/redox-os/redox/releases)
-4. [Redocs](http://www.redox-os.org/docs/)
+4. [Redocs](https://www.redox-os.org/docs/)
 5. [Fancy GitHub organization](https://github.com/redox-os)
-6. [Our Holy Grail of a Website](http://www.redox-os.org/)
-7. [The Extreme Screenshots](http://www.redox-os.org/screens/)
+6. [Our Holy Grail of a Website](https://www.redox-os.org/)
+7. [The Extreme Screenshots](https://www.redox-os.org/screens/)
 
 # New contributors
 

--- a/content/news/this-week-in-redox-6.md
+++ b/content/news/this-week-in-redox-6.md
@@ -10,7 +10,7 @@ This is the sixth post of a series of blog posts tracking the development and pr
 
 # What's new in Redox?
 
-- [@jackpot51](https://github.com/jackpot51) has done lots of changes in the kernel. The distinction between user and kernel space is now complete. You can read about all this [here](http://dictator.redox-os.org/index.php?controller=post&action=view&id_post=17).
+- [@jackpot51](https://github.com/jackpot51) has done lots of changes in the kernel. The distinction between user and kernel space is now complete. You can read about all this [here](https://dictator.redox-os.org/index.php?controller=post&action=view&id_post=17).
 
 - [@ticki](https://github.com/ticki) has written a new memory manager inspired by jemalloc. It's not merged to master yet. This change makes heap allocation much faster.
 

--- a/content/news/this-year-in-redox-18.md
+++ b/content/news/this-year-in-redox-18.md
@@ -92,24 +92,24 @@ We are also looking into a more long-term solution such as funding from a univer
 Finally, Redox has been covered in a number of news articles:
 
 - [2015-10-07 - OpenNet - Представлена операционная система Redox, написанная на языке Rust](https://www.opennet.ru/opennews/art.shtml?num=43105)
-- [2016-03-19 - OSNews - The Redox operating system](http://www.osnews.com/story/29131/The_Redox_operating_system)
+- [2016-03-19 - OSNews - The Redox operating system](https://www.osnews.com/story/29131/The_Redox_operating_system)
 - [2016-03-20 - Phoronix - Redox: A Rust-Written, Microkernel Open-Source OS](https://www.phoronix.com/scan.php?page=news_item&px=Redos-OS-Intro)
-- [2016-03-21 - InfoWorld - Rust's Redox OS could show Linux a few new tricks](http://www.infoworld.com/article/3046100/open-source-tools/rusts-redox-os-could-show-linux-a-few-new-tricks.html)
+- [2016-03-21 - InfoWorld - Rust's Redox OS could show Linux a few new tricks](https://www.infoworld.com/article/3046100/open-source-tools/rusts-redox-os-could-show-linux-a-few-new-tricks.html)
 - [2016-03-21 - TuxNews.it - Redox: nasce il sistema operativo (da 26 MB) Unix-like scritto in Rust!](http://tuxnews.it/redox-nasce-il-sistema-operativo-da-26-mb-unix-like-scritto-in-rust/)
 - [2016-03-22 - Linux.com - Rust's Redox OS Could Show Linux a Few New Tricks](https://www.linux.com/news/rusts-redox-os-could-show-linux-few-new-tricks)
-- [2016-03-22 - Pro-Linux - Betriebssystem Redox in Rust geschrieben](http://www.pro-linux.de/news/1/23383/betriebssystem-redox-in-rust-geschrieben.html)
+- [2016-03-22 - Pro-Linux - Betriebssystem Redox in Rust geschrieben](https://www.pro-linux.de/news/1/23383/betriebssystem-redox-in-rust-geschrieben.html)
 - [2016-03-22 - SoylentNews - Microkernel, Rust-Programmed Redox OS's Devs Slam Linux, Unix, GPL](https://soylentnews.org/article.pl?sid=16/03/22/0116231) (The title is their choice - not ours)
 - [2016-04-06 - LWN.net - Redox: a Rust-based microkernel](https://lwn.net/Articles/682591/)
-- [2016-05-04 - formtek - Rust Redox – An Next-Generation Attempt to Plug Linux OS Gaps](http://formtek.com/blog/operating-systems-rust-redox-an-next-generation-attempt-to-plug-linux-os-gaps/)
+- [2016-05-04 - formtek - Rust Redox – An Next-Generation Attempt to Plug Linux OS Gaps](https://formtek.com/blog/operating-systems-rust-redox-an-next-generation-attempt-to-plug-linux-os-gaps/)
 - [2016-05-24 - Laboratorio Linux - Redox OS el Sistema Operativo de Código Abierto alternativo a Linux](http://laboratoriolinux.es/index.php/-noticias-mundo-linux-/distribuciones/16043-redox-os-el-sistema-operativo-de-codigo-abierto-alternativo-a-linux.html)
 - [2016-06-16 - It's F.O.S.S. - REDOX OS: AN OPERATING SYSTEM WRITTEN IN RUST](https://itsfoss.com/redox-os-an-operating-system-written-in-rust/)
-- [2016-06-23 - Ubuntu Next - REDOX OS: YOUR NEXT GENERATION OPERATING SYSTEM](http://ubuntunext.com/2016/06/23/redox-os-your-next-generation-operating-system)
+- [2016-06-23 - Ubuntu Next - REDOX OS: YOUR NEXT GENERATION OPERATING SYSTEM](https://ubuntunext.com/2016/06/23/redox-os-your-next-generation-operating-system)
 - [2016-06-28 - Websetnet - Redox OS: an Operating System Written in Rust](https://websetnet.com/redox-os-operating-system-written-rust/)
-- [2016-11-01 - OSNews - A complete rewrite of the Redox kernel](http://www.osnews.com/story/29463/A_complete_rewrite_of_the_Redox_kernel)
-- [2016-12-09 - Golem.de - REDOX OS: Wer nicht rustet, rostet](http://www.golem.de/news/redox-os-wer-nicht-rustet-rostet-1612-124867.html)
-- [2016-12-31 - Phoronix - Rust-Based Redox OS Had A Busy Year With Rewriting Its Kernel, Writing A File-System](http://phoronix.com/scan.php?page=news_item&px=Redox-OS-2016-State)
+- [2016-11-01 - OSNews - A complete rewrite of the Redox kernel](https://www.osnews.com/story/29463/A_complete_rewrite_of_the_Redox_kernel)
+- [2016-12-09 - Golem.de - REDOX OS: Wer nicht rustet, rostet](https://www.golem.de/news/redox-os-wer-nicht-rustet-rostet-1612-124867.html)
+- [2016-12-31 - Phoronix - Rust-Based Redox OS Had A Busy Year With Rewriting Its Kernel, Writing A File-System](https://phoronix.com/scan.php?page=news_item&px=Redox-OS-2016-State)
 
 If you know of others, please create an issue at [our website repo](https://github.com/redox-os/website).
 
 Here is a composite image:
-<a href="http://i.imgur.com/dwNevsk.jpg"><img class="img-responsive" src="http://i.imgur.com/dwNevsk.jpg"/></a>
+<a href="https://i.imgur.com/dwNevsk.jpg"><img class="img-responsive" src="https://i.imgur.com/dwNevsk.jpg"/></a>

--- a/content/news/visual-refresh-19.md
+++ b/content/news/visual-refresh-19.md
@@ -30,12 +30,12 @@ I will work to improve the other applications - in the order of launcher, file m
 
 **Without further ado, here are the before and after images!**
 
-<a href="http://imgur.com/xvT3eA1.png">
+<a href="https://imgur.com/xvT3eA1.png">
 ## Login Before &amp; After:
-<img class="img-responsive" src="http://i.imgur.com/xvT3eA1.png"/>
+<img class="img-responsive" src="https://i.imgur.com/xvT3eA1.png"/>
 </a>
 
-<a href="http://imgur.com/XUsQ82U.png">
+<a href="https://imgur.com/XUsQ82U.png">
 ## Apps Before &amp; After:
-<img class="img-responsive" src="http://i.imgur.com/XUsQ82U.png"/>
+<img class="img-responsive" src="https://i.imgur.com/XUsQ82U.png"/>
 </a>


### PR DESCRIPTION
I noticed that Google still points to the HTTP address of the website (`http://www.redox-os.org/`) instead of the secure one. I know there are redirects in place but it would be so much better to properly handle it. This PR attempts to solve this problem.

I changed the base URL to HTTPS in the `config.toml` file. This results in the following changes:

* The site now reports the HTTPS address as its canonical one. Google should pick this up on its next visit.
* The sitemap XMLs now link to the HTTPS addresses instead of the HTTP ones.

I also changed the links in the content files (including the outgoing links). Sites like `microkernel.info` (https://github.com/jermar/microkernel.info/issues/9), `tuxnews.it` and `laboratoriolinux.es` have problems with HTTPS so I kept their links as HTTP.
