### PR TITLE
Fix screenshots on the home page

### DIFF
--- a/content/home.cz.md
+++ b/content/home.cz.md
@@ -38,15 +38,15 @@ url = "/home"
     <div style="font-size: 16px; text-align: center;">
       Redox running Orbital
     </div>
-    <a href="img/redox-orbital/large.png">
+    <a href="/img/redox-orbital/large.png">
       <picture>
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.webp" type="image/webp">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.png" type="image/png">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.png" type="image/png">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/small.png" type="image/png">
-        <img src="img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.webp" type="image/webp">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.png" type="image/png">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.png" type="image/png">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/small.png" type="image/png">
+        <img src="/img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
       </picture>
     </a>
   </div>

--- a/content/home.da.md
+++ b/content/home.da.md
@@ -38,15 +38,15 @@ url = "/home"
     <div style="font-size: 16px; text-align: center;">
       Redox kører Orbital
     </div>
-    <a href="img/redox-orbital/large.png">
+    <a href="/img/redox-orbital/large.png">
       <picture>
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.webp" type="image/webp">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.png" type="image/png">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.png" type="image/png">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/small.png" type="image/png">
-        <img src="img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.webp" type="image/webp">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.png" type="image/png">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.png" type="image/png">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/small.png" type="image/png">
+        <img src="/img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
       </picture>
     </a>
   </div>

--- a/content/home.de.md
+++ b/content/home.de.md
@@ -38,15 +38,15 @@ url = "/home"
     <div style="font-size: 16px; text-align: center;">
       Redox unter Orbital
     </div>
-    <a href="img/redox-orbital/large.png">
+    <a href="/img/redox-orbital/large.png">
       <picture>
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.webp" type="image/webp">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.png" type="image/png">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.png" type="image/png">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/small.png" type="image/png">
-        <img src="img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.webp" type="image/webp">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.png" type="image/png">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.png" type="image/png">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/small.png" type="image/png">
+        <img src="/img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
       </picture>
     </a>
   </div>

--- a/content/home.en.md
+++ b/content/home.en.md
@@ -38,15 +38,15 @@ url = "/home"
     <div style="font-size: 16px; text-align: center;">
       Redox running Orbital
     </div>
-    <a href="img/redox-orbital/large.png">
+    <a href="/img/redox-orbital/large.png">
       <picture>
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.webp" type="image/webp">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.png" type="image/png">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.png" type="image/png">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/small.png" type="image/png">
-        <img src="img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.webp" type="image/webp">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.png" type="image/png">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.png" type="image/png">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/small.png" type="image/png">
+        <img src="/img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
       </picture>
     </a>
   </div>

--- a/content/home.eo.md
+++ b/content/home.eo.md
@@ -38,15 +38,15 @@ url = "/home"
     <div style="font-size: 16px; text-align: center;">
       Redox kurante Orbital
     </div>
-    <a href="img/redox-orbital/large.png">
+    <a href="/img/redox-orbital/large.png">
       <picture>
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.webp" type="image/webp">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.png" type="image/png">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.png" type="image/png">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/small.png" type="image/png">
-        <img src="img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.webp" type="image/webp">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.png" type="image/png">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.png" type="image/png">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/small.png" type="image/png">
+        <img src="/img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
       </picture>
     </a>
   </div>

--- a/content/home.es.md
+++ b/content/home.es.md
@@ -38,15 +38,15 @@ url = "/home"
     <div style="font-size: 16px; text-align: center;">
       Redox ejecutando Orbital
     </div>
-    <a href="img/redox-orbital/large.png">
+    <a href="/img/redox-orbital/large.png">
       <picture>
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.webp" type="image/webp">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.png" type="image/png">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.png" type="image/png">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/small.png" type="image/png">
-        <img src="img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.webp" type="image/webp">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.png" type="image/png">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.png" type="image/png">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/small.png" type="image/png">
+        <img src="/img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
       </picture>
     </a>
   </div>

--- a/content/home.fr.md
+++ b/content/home.fr.md
@@ -41,15 +41,15 @@ url = "/home"
     <div style="font-size: 16px; text-align: center;">
       Redox avec Orbital
     </div>
-    <a href="img/redox-orbital/large.png">
+    <a href="/img/redox-orbital/large.png">
       <picture>
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.webp" type="image/webp">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.png" type="image/png">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.png" type="image/png">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/small.png" type="image/png">
-        <img src="img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.webp" type="image/webp">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.png" type="image/png">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.png" type="image/png">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/small.png" type="image/png">
+        <img src="/img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
       </picture>
     </a>
   </div>

--- a/content/home.hu.md
+++ b/content/home.hu.md
@@ -37,15 +37,15 @@ url = "/home"
     <div style="font-size: 16px; text-align: center;">
       Orbital futtatása Redox alatt
     </div>
-    <a href="img/redox-orbital/large.png">
+    <a href="/img/redox-orbital/large.png">
       <picture>
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.webp" type="image/webp">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.png" type="image/png">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.png" type="image/png">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/small.png" type="image/png">
-        <img src="img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.webp" type="image/webp">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.png" type="image/png">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.png" type="image/png">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/small.png" type="image/png">
+        <img src="/img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
       </picture>
     </a>
   </div>

--- a/content/home.it.md
+++ b/content/home.it.md
@@ -38,15 +38,15 @@ url = "/home"
     <div style="font-size: 16px; text-align: center;">
       Redox con Orbital
     </div>
-    <a href="img/redox-orbital/large.png">
+    <a href="/img/redox-orbital/large.png">
       <picture>
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.webp" type="image/webp">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.png" type="image/png">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.png" type="image/png">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/small.png" type="image/png">
-        <img src="img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.webp" type="image/webp">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.png" type="image/png">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.png" type="image/png">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/small.png" type="image/png">
+        <img src="/img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
       </picture>
     </a>
   </div>

--- a/content/home.jp.md
+++ b/content/home.jp.md
@@ -38,15 +38,15 @@ url = "/home"
     <div style="font-size: 16px; text-align: center;">
       RedoxがOrbitalを実行している様子
     </div>
-    <a href="img/redox-orbital/large.png">
+    <a href="/img/redox-orbital/large.png">
       <picture>
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.webp" type="image/webp">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.png" type="image/png">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.png" type="image/png">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/small.png" type="image/png">
-        <img src="img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.webp" type="image/webp">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.png" type="image/png">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.png" type="image/png">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/small.png" type="image/png">
+        <img src="/img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
       </picture>
     </a>
   </div>

--- a/content/home.ko.md
+++ b/content/home.ko.md
@@ -38,15 +38,15 @@ url = "/home"
     <div style="font-size: 16px; text-align: center;">
       Orbital을 사용중인 Redox
     </div>
-    <a href="img/redox-orbital/large.png">
+    <a href="/img/redox-orbital/large.png">
       <picture>
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.webp" type="image/webp">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.png" type="image/png">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.png" type="image/png">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/small.png" type="image/png">
-        <img src="img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.webp" type="image/webp">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.png" type="image/png">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.png" type="image/png">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/small.png" type="image/png">
+        <img src="/img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
       </picture>
     </a>
   </div>

--- a/content/home.nl.md
+++ b/content/home.nl.md
@@ -38,15 +38,15 @@ url = "/home"
     <div style="font-size: 16px; text-align: center;">
       Redox met Orbital
     </div>
-    <a href="img/redox-orbital/large.png">
+    <a href="/img/redox-orbital/large.png">
       <picture>
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.webp" type="image/webp">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.png" type="image/png">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.png" type="image/png">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/small.png" type="image/png">
-        <img src="img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.webp" type="image/webp">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.png" type="image/png">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.png" type="image/png">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/small.png" type="image/png">
+        <img src="/img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
       </picture>
     </a>
   </div>

--- a/content/home.no.md
+++ b/content/home.no.md
@@ -38,15 +38,15 @@ url = "/home"
     <div style="font-size: 16px; text-align: center;">
       Redox kjører Orbital
     </div>
-    <a href="img/redox-orbital/large.png">
+    <a href="/img/redox-orbital/large.png">
       <picture>
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.webp" type="image/webp">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.png" type="image/png">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.png" type="image/png">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/small.png" type="image/png">
-        <img src="img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.webp" type="image/webp">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.png" type="image/png">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.png" type="image/png">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/small.png" type="image/png">
+        <img src="/img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
       </picture>
     </a>
   </div>

--- a/content/home.pl.md
+++ b/content/home.pl.md
@@ -37,15 +37,15 @@ url = "/home"
     <div style="font-size: 16px; text-align: center;">
       Redox ze środowiskiem Orbital
     </div>
-    <a href="img/redox-orbital/large.png">
+    <a href="/img/redox-orbital/large.png">
       <picture>
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.webp" type="image/webp">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.png" type="image/png">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.png" type="image/png">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/small.png" type="image/png">
-        <img src="img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.webp" type="image/webp">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.png" type="image/png">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.png" type="image/png">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/small.png" type="image/png">
+        <img src="/img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
       </picture>
     </a>
   </div>

--- a/content/home.pt.md
+++ b/content/home.pt.md
@@ -38,15 +38,15 @@ url = "/home"
     <div style="font-size: 16px; text-align: center;">
       Redox executando Orbital
     </div>
-    <a href="img/redox-orbital/large.png">
+    <a href="/img/redox-orbital/large.png">
       <picture>
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.webp" type="image/webp">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.png" type="image/png">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.png" type="image/png">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/small.png" type="image/png">
-        <img src="img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.webp" type="image/webp">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.png" type="image/png">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.png" type="image/png">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/small.png" type="image/png">
+        <img src="/img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
       </picture>
     </a>
   </div>

--- a/content/home.ru.md
+++ b/content/home.ru.md
@@ -38,15 +38,15 @@ url = "/home"
     <div style="font-size: 16px; text-align: center;">
       Redox с Orbital
     </div>
-    <a href="img/redox-orbital/large.png">
+    <a href="/img/redox-orbital/large.png">
       <picture>
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.webp" type="image/webp">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.png" type="image/png">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.png" type="image/png">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/small.png" type="image/png">
-        <img src="img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.webp" type="image/webp">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.png" type="image/png">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.png" type="image/png">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/small.png" type="image/png">
+        <img src="/img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
       </picture>
     </a>
   </div>

--- a/content/home.sv.md
+++ b/content/home.sv.md
@@ -38,15 +38,15 @@ url = "/home"
     <div style="font-size: 16px; text-align: center;">
       Redox kör Orbital
     </div>
-    <a href="img/redox-orbital/large.png">
+    <a href="/img/redox-orbital/large.png">
       <picture>
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.webp" type="image/webp">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.png" type="image/png">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.png" type="image/png">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/small.png" type="image/png">
-        <img src="img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.webp" type="image/webp">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.png" type="image/png">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.png" type="image/png">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/small.png" type="image/png">
+        <img src="/img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
       </picture>
     </a>
   </div>

--- a/content/home.tr.md
+++ b/content/home.tr.md
@@ -38,15 +38,15 @@ url = "/home"
     <div style="font-size: 16px; text-align: center;">
       Redox Orbital'i çalıştırırken
     </div>
-    <a href="img/redox-orbital/large.png">
+    <a href="/img/redox-orbital/large.png">
       <picture>
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.webp" type="image/webp">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.png" type="image/png">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.png" type="image/png">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/small.png" type="image/png">
-        <img src="img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.webp" type="image/webp">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.png" type="image/png">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.png" type="image/png">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/small.png" type="image/png">
+        <img src="/img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
       </picture>
     </a>
   </div>

--- a/content/home.uk.md
+++ b/content/home.uk.md
@@ -38,15 +38,15 @@ url = "/home"
     <div style="font-size: 16px; text-align: center;">
       Redox із Orbital
     </div>
-    <a href="img/redox-orbital/large.png">
+    <a href="/img/redox-orbital/large.png">
       <picture>
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.webp" type="image/webp">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.png" type="image/png">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.png" type="image/png">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/small.png" type="image/png">
-        <img src="img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.webp" type="image/webp">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.png" type="image/png">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.png" type="image/png">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/small.png" type="image/png">
+        <img src="/img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
       </picture>
     </a>
   </div>

--- a/content/home.zh.md
+++ b/content/home.zh.md
@@ -38,15 +38,15 @@ url = "/home"
     <div style="font-size: 16px; text-align: center;">
       Redox执行Orbital
     </div>
-    <a href="img/redox-orbital/large.png">
+    <a href="/img/redox-orbital/large.png">
       <picture>
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.webp" type="image/webp">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/medium.webp" type="image/webp">
-        <source media="(min-width: 1300px)" srcset="img/redox-orbital/large.png" type="image/png">
-        <source media="(min-width: 640px)" srcset="img/redox-orbital/medium.png" type="image/png">
-        <source media="(min-width: 320px)" srcset="img/redox-orbital/small.png" type="image/png">
-        <img src="img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.webp" type="image/webp">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/medium.webp" type="image/webp">
+        <source media="(min-width: 1300px)" srcset="/img/redox-orbital/large.png" type="image/png">
+        <source media="(min-width: 640px)" srcset="/img/redox-orbital/medium.png" type="image/png">
+        <source media="(min-width: 320px)" srcset="/img/redox-orbital/small.png" type="image/png">
+        <img src="/img/redox-orbital/medium.png" class="img-responsive" alt="Redox and Orbital">
       </picture>
     </a>
   </div>


### PR DESCRIPTION
The translated home pages tried to load the screenshots from `https://www.redox-os.org/<lang>/img/...` instead of `https://www.redox-os.org/img/...` due to the missing leading slashes in the image paths.